### PR TITLE
retry contact events up to three times

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -12,10 +12,11 @@ import (
 
 // Task is a utility struct for encoding a task
 type Task struct {
-	Type     string          `json:"type"`
-	OrgID    int             `json:"org_id"`
-	Task     json.RawMessage `json:"task"`
-	QueuedOn time.Time       `json:"queued_on"`
+	Type       string          `json:"type"`
+	OrgID      int             `json:"org_id"`
+	Task       json.RawMessage `json:"task"`
+	QueuedOn   time.Time       `json:"queued_on"`
+	ErrorCount int             `json:"error_count,omitempty"`
 }
 
 // Priority is the priority for the task


### PR DESCRIPTION
This will cause us to retry events in the case of errors up to three times. It will retry the event before attempting to process any more events for that contact, so in the case of messages it should still process them in order, even in the case of failures.

Right now there's no pause in the retry apart from the inherit queue delay which in most cases is going to be very small. Figure we start with the simplest thing first and see if we need to add some kind of delay before retries instead, which gets more complicated.