### PR TITLE
dont create outgoing ivr messages (internally) when resuming a comple…

### DIFF
--- a/hooks/ivr_created.go
+++ b/hooks/ivr_created.go
@@ -70,6 +70,11 @@ func handleIVRCreated(ctx context.Context, tx *sqlx.Tx, rp *redis.Pool, org *mod
 		return errors.Errorf("ivr sessions must have a channel connection set")
 	}
 
+	// if our call is no longer in progress, return
+	if conn.Status() != models.ConnectionStatusInProgress {
+		return nil
+	}
+
 	msg, err := models.NewOutgoingIVR(org.OrgID(), conn, event.Msg, event.CreatedOn())
 	if err != nil {
 		return errors.Wrapf(err, "error creating outgoing ivr say: %s", event.Msg.Text())


### PR DESCRIPTION
This is the weird case when somebody connects a call, then hangs up. We actually want the flow to continue in this case (customers depend on it, calling webhooks, sending emails etc), but we don't want to create the outgoing IVR messages because that's a bit confusing on the contact history page.

fixes: #109 