### PR TITLE
remove references to unused fields

### DIFF
--- a/campaigns/campaigns_test.go
+++ b/campaigns/campaigns_test.go
@@ -21,7 +21,6 @@ func TestCampaigns(t *testing.T) {
 	// let's create a campaign event fire for one of our contacts (for now this is totally hacked, they aren't in the group and
 	// their relative to date isn't relative, but this still tests execution)
 	db := testsuite.DB()
-	db.MustExec(`UPDATE flows_flow SET flow_server_enabled=TRUE WHERE id = $1;`, models.FavoritesFlowID)
 	db.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, models.CathyID, models.GeorgeID, models.RemindersEvent1ID)
 	time.Sleep(10 * time.Millisecond)
 
@@ -53,7 +52,6 @@ func TestIVRCampaigns(t *testing.T) {
 	// let's create a campaign event fire for one of our contacts (for now this is totally hacked, they aren't in the group and
 	// their relative to date isn't relative, but this still tests execution)
 	db := testsuite.DB()
-	db.MustExec(`UPDATE flows_flow SET flow_server_enabled=TRUE WHERE id = $1;`, models.IVRFlowID)
 	db.MustExec(`UPDATE campaigns_campaignevent SET flow_id = $1 WHERE id = $2`, models.IVRFlowID, models.RemindersEvent1ID)
 	db.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, models.CathyID, models.GeorgeID, models.RemindersEvent1ID)
 	time.Sleep(10 * time.Millisecond)

--- a/campaigns/cron.go
+++ b/campaigns/cron.go
@@ -188,7 +188,7 @@ WHERE
     ef.fired IS NULL AND ef.scheduled <= NOW() AND
 	ce.id = ef.event_id AND
 	ce.is_active = TRUE AND
-    f.id = ce.flow_id AND f.flow_server_enabled = TRUE AND
+    f.id = ce.flow_id AND
     ce.campaign_id = c.id
 ORDER BY
     DATE_TRUNC('minute', scheduled) ASC,

--- a/expirations/cron.go
+++ b/expirations/cron.go
@@ -140,8 +140,7 @@ const selectExpiredRunsSQL = `
 		fr.is_active = TRUE AND
 		fr.expires_on < NOW() AND
 		fr.connection_id IS NULL AND
-		fr.session_id IS NOT NULL AND
-		o.flow_server_enabled = TRUE
+		fr.session_id IS NOT NULL
 	ORDER BY
 		expires_on ASC
 	LIMIT 25000

--- a/expirations/cron_test.go
+++ b/expirations/cron_test.go
@@ -31,7 +31,6 @@ func TestExpirations(t *testing.T) {
 
 	// need to create a session that has an expired timeout
 	db := testsuite.DB()
-	db.MustExec(`UPDATE orgs_org SET flow_server_enabled=TRUE WHERE id = 1;`)
 
 	// create a few sessions
 	var s1, s2 models.SessionID

--- a/models/contacts.go
+++ b/models/contacts.go
@@ -422,9 +422,9 @@ func CreateContact(ctx context.Context, db *sqlx.DB, org *OrgAssets, assets flow
 	err = tx.GetContext(ctx, &contactID,
 		`INSERT INTO 
 		contacts_contact
-			(org_id, is_active, is_blocked, is_test, is_stopped, uuid, created_on, modified_on, created_by_id, modified_by_id, name) 
+			(org_id, is_active, is_blocked, is_stopped, uuid, created_on, modified_on, created_by_id, modified_by_id, name) 
 		VALUES
-			($1, TRUE, FALSE, FALSE, FALSE, $2, NOW(), NOW(), 1, 1, '')
+			($1, TRUE, FALSE, FALSE, $2, NOW(), NOW(), 1, 1, '')
 		RETURNING id`,
 		org.OrgID(), utils.NewUUID(),
 	)

--- a/models/webhook_event.go
+++ b/models/webhook_event.go
@@ -7,22 +7,10 @@ import (
 
 type WebhookEventID int64
 
-type EventType string
-
-type EventStatus string
-
-const (
-	EventTypeFlow = EventType("flow")
-
-	EventStatusComplete = EventStatus("C")
-)
-
 // WebhookEvent represents an event that was created, mostly used for resthooks
 type WebhookEvent struct {
 	e struct {
 		ID         WebhookEventID `db:"id"`
-		EventType  EventType      `db:"event"`
-		Status     EventStatus    `db:"status"`
 		Data       string         `db:"data"`
 		ResthookID ResthookID     `db:"resthook_id"`
 		OrgID      OrgID          `db:"org_id"`
@@ -37,8 +25,6 @@ func NewWebhookEvent(orgID OrgID, resthookID ResthookID, data string, createdOn 
 	event := &WebhookEvent{}
 	e := &event.e
 
-	e.EventType = EventTypeFlow
-	e.Status = EventStatusComplete
 	e.Data = data
 	e.OrgID = orgID
 	e.ResthookID = resthookID
@@ -48,8 +34,8 @@ func NewWebhookEvent(orgID OrgID, resthookID ResthookID, data string, createdOn 
 }
 
 const insertWebhookEventsSQL = `
-INSERT INTO	api_webhookevent( event,  status,  data,  resthook_id,  org_id,  created_on, try_count, action)
-					  VALUES(:event, :status, :data, :resthook_id, :org_id, :created_on, 1,         'POST')
+INSERT INTO	api_webhookevent(data,  resthook_id,  org_id,  created_on, action)
+					  VALUES(:data, :resthook_id, :org_id, :created_on, 'POST')
 RETURNING id
 `
 

--- a/models/webhook_event_test.go
+++ b/models/webhook_event_test.go
@@ -31,8 +31,7 @@ func TestWebhookEvents(t *testing.T) {
 		assert.NotZero(t, e.ID())
 
 		testsuite.AssertQueryCount(t, db, `
-		SELECT count(*) FROM api_webhookevent WHERE org_id = $1 AND resthook_id = $2 AND data = $3 AND status = 'C' AND
-		event = 'flow'
+		SELECT count(*) FROM api_webhookevent WHERE org_id = $1 AND resthook_id = $2 AND data = $3
 		`, []interface{}{tc.OrgID, tc.ResthookID, tc.Data}, 1)
 	}
 }

--- a/timeouts/cron.go
+++ b/timeouts/cron.go
@@ -106,7 +106,6 @@ const timedoutSessionsSQL = `
 	WHERE 
 		status = 'W' AND 
 		timeout_on < NOW() AND
-		o.flow_server_enabled = TRUE AND
 		connection_id IS NULL
 	ORDER BY 
 		timeout_on ASC

--- a/timeouts/cron_test.go
+++ b/timeouts/cron_test.go
@@ -26,7 +26,6 @@ func TestTimeouts(t *testing.T) {
 
 	// need to create a session that has an expired timeout
 	db := testsuite.DB()
-	db.MustExec(`UPDATE orgs_org SET flow_server_enabled=TRUE WHERE id = 1;`)
 	db.MustExec(`INSERT INTO flows_flowsession(org_id, status, responded, contact_id, created_on, timeout_on) VALUES (1, 'W', TRUE, $1, NOW(), NOW());`, models.CathyID)
 	db.MustExec(`INSERT INTO flows_flowsession(org_id, status, responded, contact_id, created_on, timeout_on) VALUES (1, 'W', TRUE, $1, NOW(), NOW()+ interval '1' day);`, models.GeorgeID)
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
stops reading / writing, flow_server_enabled, contact.is_test and webhook event fields.