### PR TITLE
override default max digits of 4 for nexmo gathers

### DIFF
--- a/ivr/nexmo/nexmo.go
+++ b/ivr/nexmo/nexmo.go
@@ -666,8 +666,11 @@ func (c *client) responseForSprint(resumeURL string, w flows.ActivatedWait, es [
 				EventURL:     []string{eventURL},
 				EventMethod:  http.MethodPost,
 			}
+			// limit our digits if asked to
 			if hint.Count != nil {
 				input.MaxDigits = *hint.Count
+			} else {
+				input.MaxDigits = 20
 			}
 			waitActions = append(waitActions, input)
 

--- a/ivr/nexmo/nexmo_test.go
+++ b/ivr/nexmo/nexmo_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/goflow/flows/routers/waits"
 	"github.com/nyaruka/goflow/flows/routers/waits/hints"
-	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/test"
+	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/config"
 	"github.com/nyaruka/mailroom/models"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -91,7 +91,7 @@ func TestResponseForSprint(t *testing.T) {
 		{
 			[]flows.Event{events.NewIVRCreatedEvent(flows.NewMsgOut(urn, channelRef, "enter a number, then press #", nil, nil, nil))},
 			waits.NewActivatedMsgWait(nil, hints.NewTerminatedDigitsHint("#")),
-			`[{"action":"talk","text":"enter a number, then press #","bargeIn":true},{"action":"input","submitOnHash":true,"timeOut":30,"eventUrl":["http://temba.io/resume?session=1\u0026wait_type=gather\u0026sig=OjsMUDhaBTUVLq1e6I4cM0SKYpk%3D"],"eventMethod":"POST"}]`,
+			`[{"action":"talk","text":"enter a number, then press #","bargeIn":true},{"action":"input","maxDigits":20,"submitOnHash":true,"timeOut":30,"eventUrl":["http://temba.io/resume?session=1\u0026wait_type=gather\u0026sig=OjsMUDhaBTUVLq1e6I4cM0SKYpk%3D"],"eventMethod":"POST"}]`,
 		},
 		{
 			[]flows.Event{events.NewIVRCreatedEvent(flows.NewMsgOut(urn, channelRef, "say something", nil, nil, nil))},


### PR DESCRIPTION
Nexmo by default limits IVR digit gathers to 4 digits. This changes the default to be 20, their max. (you can still submit by pressing `#`)