### PR TITLE
🚨 Fix endpoints so we don't hard error for expected requests

### DIFF
--- a/web/flow/flow_test.go
+++ b/web/flow/flow_test.go
@@ -65,9 +65,9 @@ func TestServer(t *testing.T) {
 
 		{URL: "/mr/flow/clone", Method: "GET", Status: 405, Response: `{"error": "illegal method: GET"}`},
 		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_valid.json", Status: 200, ResponsePattern: `"uuid": "1cf84575-ee14-4253-88b6-e3675c04a066"`},
-		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_struct_invalid.json", Status: 422, Response: `{"error": "unable to read node: field 'uuid' is required"}`},
+		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_struct_invalid.json", Status: 422, Response: `{"error": "unable to read flow: unable to read node: field 'uuid' is required"}`},
 		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_missing_dep_mapping.json", Status: 422, ResponsePattern: `group\[uuid=[-0-9a-f]{36},name=Testers\]`},
-		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_valid_bad_org.json", Status: 400, Response: `{"error": "error loading environment for org 167733: no org with id: 167733"}`},
+		{URL: "/mr/flow/clone", Method: "POST", BodyFile: "clone_valid_bad_org.json", Status: 500, Response: `{"error": "error loading environment for org 167733: no org with id: 167733"}`},
 	}
 
 	for _, tc := range tcs {

--- a/web/flow/testdata/inspect_invalid.response.json
+++ b/web/flow/testdata/inspect_invalid.response.json
@@ -1,3 +1,3 @@
 {
-    "error": "invalid node[uuid=6fde1a09-3997-47dd-aff0-92e8aff3a642]: destination 55fbef81-4151-4589-9f0a-8e5c44f6b5a3 of exit[uuid=d3f3f024-a90e-43a5-bd5a-7056f5bea699] isn't a known node"
+    "error": "unable to read flow: invalid node[uuid=6fde1a09-3997-47dd-aff0-92e8aff3a642]: destination 55fbef81-4151-4589-9f0a-8e5c44f6b5a3 of exit[uuid=d3f3f024-a90e-43a5-bd5a-7056f5bea699] isn't a known node"
 }

--- a/web/flow/testdata/inspect_invalid_legacy.response.json
+++ b/web/flow/testdata/inspect_invalid_legacy.response.json
@@ -1,3 +1,3 @@
 {
-    "error": "missing dependencies: field[key=birthdate,name=],group[uuid=1465eb20-066d-4933-a8b4-62fe7b19fd39,name=I Don't Exist]"
+    "error": "flow failed validation: missing dependencies: field[key=birthdate,name=],group[uuid=1465eb20-066d-4933-a8b4-62fe7b19fd39,name=I Don't Exist]"
 }

--- a/web/flow/testdata/validate_invalid.response.json
+++ b/web/flow/testdata/validate_invalid.response.json
@@ -1,3 +1,3 @@
 {
-    "error": "invalid node[uuid=6fde1a09-3997-47dd-aff0-92e8aff3a642]: destination 55fbef81-4151-4589-9f0a-8e5c44f6b5a3 of exit[uuid=d3f3f024-a90e-43a5-bd5a-7056f5bea699] isn't a known node"
+    "error": "unable to read flow: invalid node[uuid=6fde1a09-3997-47dd-aff0-92e8aff3a642]: destination 55fbef81-4151-4589-9f0a-8e5c44f6b5a3 of exit[uuid=d3f3f024-a90e-43a5-bd5a-7056f5bea699] isn't a known node"
 }

--- a/web/flow/testdata/validate_invalid_legacy.response.json
+++ b/web/flow/testdata/validate_invalid_legacy.response.json
@@ -1,3 +1,3 @@
 {
-    "error": "missing dependencies: field[key=birthdate,name=],group[uuid=1465eb20-066d-4933-a8b4-62fe7b19fd39,name=I Don't Exist]"
+    "error": "flow failed validation: missing dependencies: field[key=birthdate,name=],group[uuid=1465eb20-066d-4933-a8b4-62fe7b19fd39,name=I Don't Exist]"
 }

--- a/web/server.go
+++ b/web/server.go
@@ -113,7 +113,7 @@ func RequireUserToken(handler JSONHandler) JSONHandler {
 	return func(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
 		token := r.Header.Get("authorization")
 		if !strings.HasPrefix(token, "Token ") {
-			return nil, http.StatusUnauthorized, errors.New("missing authorization header")
+			return errors.New("missing authorization header"), http.StatusUnauthorized, nil
 		}
 
 		// pull out the actual token
@@ -138,18 +138,18 @@ func RequireUserToken(handler JSONHandler) JSONHandler {
 		`, token)
 
 		if err != nil {
-			return nil, http.StatusUnauthorized, errors.Wrapf(err, "error looking up authorization header")
+			return errors.Wrapf(err, "error looking up authorization header"), http.StatusUnauthorized, nil
 		}
 
 		if !rows.Next() {
-			return nil, http.StatusUnauthorized, errors.Errorf("invalid authorization header")
+			return errors.Errorf("invalid authorization header"), http.StatusUnauthorized, nil
 		}
 
 		var userID int64
 		var orgID models.OrgID
 		err = rows.Scan(&userID, &orgID)
 		if err != nil {
-			return nil, http.StatusServiceUnavailable, errors.Wrapf(err, "error scanning auth row")
+			return nil, 0, errors.Wrapf(err, "error scanning auth row")
 		}
 
 		// we are authenticated set our user id ang org id on our context and call our sub handler
@@ -164,7 +164,7 @@ func RequireAuthToken(handler JSONHandler) JSONHandler {
 	return func(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
 		auth := r.Header.Get("authorization")
 		if s.Config.AuthToken != "" && fmt.Sprintf("Token %s", s.Config.AuthToken) != auth {
-			return nil, http.StatusUnauthorized, fmt.Errorf("invalid or missing authorization header, denying")
+			return fmt.Errorf("invalid or missing authorization header, denying"), http.StatusUnauthorized, nil
 		}
 
 		// we are authenticated, call our chain
@@ -178,9 +178,15 @@ func (s *Server) WrapJSONHandler(handler JSONHandler) http.HandlerFunc {
 		w.Header().Set("Content-type", "application/json")
 
 		value, status, err := handler(r.Context(), s, r)
+
+		// handler errored (a hard error)
 		if err != nil {
-			value = map[string]string{
-				"error": err.Error(),
+			value = errorAsResponse(err)
+		} else {
+			// handler returned an error to use as a the response
+			asError, isError := value.(error)
+			if isError {
+				value = errorAsResponse(asError)
 			}
 		}
 
@@ -194,7 +200,7 @@ func (s *Server) WrapJSONHandler(handler JSONHandler) http.HandlerFunc {
 
 		if err != nil {
 			logrus.WithError(err).WithField("http_request", r).Error("error handling request")
-			w.WriteHeader(status)
+			w.WriteHeader(http.StatusInternalServerError)
 			w.Write(serialized)
 			return
 		}
@@ -214,10 +220,7 @@ func (s *Server) WrapHandler(handler Handler) http.HandlerFunc {
 
 		logrus.WithError(err).WithField("http_request", r).Error("error handling request")
 		w.WriteHeader(http.StatusInternalServerError)
-		value := map[string]string{
-			"error": err.Error(),
-		}
-		serialized, _ := json.Marshal(value)
+		serialized, _ := json.Marshal(errorAsResponse(err))
 		w.Write(serialized)
 		return
 	}
@@ -261,11 +264,11 @@ func handleIndex(ctx context.Context, s *Server, r *http.Request) (interface{}, 
 }
 
 func handle404(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
-	return nil, http.StatusNotFound, errors.Errorf("not found: %s", r.URL.String())
+	return errors.Errorf("not found: %s", r.URL.String()), http.StatusNotFound, nil
 }
 
 func handle405(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
-	return nil, http.StatusMethodNotAllowed, errors.Errorf("illegal method: %s", r.Method)
+	return errors.Errorf("illegal method: %s", r.Method), http.StatusMethodNotAllowed, nil
 }
 
 type Server struct {
@@ -278,4 +281,10 @@ type Server struct {
 	wg *sync.WaitGroup
 
 	httpServer *http.Server
+}
+
+func errorAsResponse(err error) interface{} {
+	return map[string]string{
+		"error": err.Error(),
+	}
 }

--- a/web/surveyor/surveyor_test.go
+++ b/web/surveyor/surveyor_test.go
@@ -108,6 +108,7 @@ func TestSurveyor(t *testing.T) {
 	}
 
 	for i, tc := range tcs {
+		testID := fmt.Sprintf("%s[token=%s]", tc.File, tc.Token)
 		path := filepath.Join("testdata", tc.File)
 		submission, err := ioutil.ReadFile(path)
 		assert.NoError(t, err)
@@ -122,10 +123,10 @@ func TestSurveyor(t *testing.T) {
 		}
 
 		resp, err := http.DefaultClient.Do(req)
-		assert.Equal(t, tc.StatusCode, resp.StatusCode)
+		assert.Equal(t, tc.StatusCode, resp.StatusCode, "unexpected status code for %s", testID)
 
 		body, _ := ioutil.ReadAll(resp.Body)
-		assert.Containsf(t, string(body), tc.Contains, "%d does not contain expected body", i)
+		assert.Containsf(t, string(body), tc.Contains, "%s does not contain expected body", testID)
 
 		id, _ := jsonparser.GetInt(body, "contact", "id")
 		args.ContactID = flows.ContactID(id)


### PR DESCRIPTION
Ended up tweaking things to try and clarify the contract for handler functions. Sometimes you want to return an error as a normal response (e.g. a flow failed validation, goflow gives us an error describing why), and sometimes an error means something unexpected happened, please log to sentry.

Handlers have 3 return values: response, status_code, err. So this change means..

 - If you want your error to be a response, return it as the response with a status code
 - If you want your error to be a hard error, just return it as the error, and nothing for the other values