### PR TITLE
🔥  fix leaking db conns

### DIFF
--- a/models/channel_connection.go
+++ b/models/channel_connection.go
@@ -141,6 +141,7 @@ func InsertIVRConnection(ctx context.Context, db *sqlx.DB, orgID OrgID, channelI
 	if err != nil {
 		return nil, errors.Wrapf(err, "error inserting new channel connection")
 	}
+	defer rows.Close()
 
 	rows.Next()
 

--- a/models/contacts.go
+++ b/models/contacts.go
@@ -506,6 +506,9 @@ func URNForURN(ctx context.Context, tx Queryer, org *OrgAssets, u urns.URN) (urn
 		`SELECT row_to_json(r) FROM (SELECT id, scheme, path, display, auth, channel_id, priority FROM contacts_contacturn WHERE identity = $1 AND org_id = $2) r;`,
 		u.Identity(), org.OrgID(),
 	)
+	if err != nil {
+		return urns.NilURN, errors.Errorf("error selecting URN: %s", u.Identity())
+	}
 	defer rows.Close()
 
 	if !rows.Next() {
@@ -564,6 +567,11 @@ func URNForID(ctx context.Context, tx Queryer, org *OrgAssets, urnID URNID) (urn
 		`SELECT row_to_json(r) FROM (SELECT id, scheme, path, display, auth, channel_id, priority FROM contacts_contacturn WHERE id = $1) r;`,
 		urnID,
 	)
+	if err != nil {
+		return urns.NilURN, errors.Errorf("error selecting URN ID: %d", urnID)
+	}
+	defer rows.Close()
+
 	if !rows.Next() {
 		return urns.NilURN, errors.Errorf("no urn with id: %d", urnID)
 	}

--- a/web/server.go
+++ b/web/server.go
@@ -136,10 +136,10 @@ func RequireUserToken(handler JSONHandler) JSONHandler {
 			o.is_active = TRUE AND
 			u.is_active = TRUE
 		`, token)
-
 		if err != nil {
 			return errors.Wrapf(err, "error looking up authorization header"), http.StatusUnauthorized, nil
 		}
+		defer rows.Close()
 
 		if !rows.Next() {
 			return errors.Errorf("invalid authorization header"), http.StatusUnauthorized, nil


### PR DESCRIPTION
We are leaking db conns (almost certainly via a missing `rows.Close()`) causing a deadlock after a while. Found a few possible spots after looking at all our uses of `Query*`, URN related ones are most likely culprits since that recently changed (though they aren't new). Other possibility is the auth endpoint, which may be triggered by different usage all of a sudden (more surveyor submissions), the check of auth tokens was leaking a conn on every hit.