### PR TITLE
Deal with handles for contacts that no longer have a URN

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -48,6 +48,9 @@ func TestMsgEvents(t *testing.T) {
 									  flow_id, trigger_type, match_type, created_by_id, modified_by_id, org_id, trigger_count)
 		VALUES(TRUE, now(), now(), 'ivr', false, $1, 'K', 'O', 1, 1, 1, 0) RETURNING id`, models.IVRFlowID)
 
+	// clear all of Alexandria's URNs
+	db.MustExec(`UPDATE contacts_contacturn SET contact_id = NULL WHERE contact_id = $1`, models.AlexandriaID)
+
 	models.FlushCache()
 
 	tcs := []struct {
@@ -78,6 +81,9 @@ func TestMsgEvents(t *testing.T) {
 		{models.Org2FredID, models.Org2FredURN, models.Org2FredURNID, "start", "What is your favorite color?", models.Org2ChannelID, models.Org2},
 
 		{models.BobID, models.BobURN, models.BobURNID, "ivr", "", models.TwitterChannelID, models.Org1},
+
+		// no URN on contact but handle event, session gets started but no message created
+		{models.AlexandriaID, models.AlexandriaURN, models.AlexandriaURNID, "start", "", models.TwilioChannelID, models.Org1},
 	}
 
 	makeMsgTask := func(orgID models.OrgID, channelID models.ChannelID, contactID models.ContactID, urn urns.URN, urnID models.URNID, text string) *queue.Task {

--- a/handler/worker.go
+++ b/handler/worker.go
@@ -509,10 +509,12 @@ func handleMsgEvent(ctx context.Context, db *sqlx.DB, rp *redis.Pool, event *Msg
 	// load the channel for this message
 	channel := org.ChannelByID(event.ChannelID)
 
-	// make sure this URN is our highest priority (this is usually a noop)
-	err = modelContact.UpdatePreferredURN(ctx, db, org, event.URNID, channel)
-	if err != nil {
-		return errors.Wrapf(err, "error changing primary URN")
+	// if we have URNs make sure the message URN is our highest priority (this is usually a noop)
+	if len(modelContact.URNs()) > 0 {
+		err = modelContact.UpdatePreferredURN(ctx, db, org, event.URNID, channel)
+		if err != nil {
+			return errors.Wrapf(err, "error changing primary URN")
+		}
 	}
 
 	// build our flow contact


### PR DESCRIPTION
Super edge case of a user removing the URN on a contact after courier has received it but before mailroom handles it. We still handle the message but can't set preferred URN on it (and no outgoing message is created). Before we were blowing up trying to set the preferred URN. (this was the single unhandled incoming on textit)