### PR TITLE
Add PostgreSQL 11 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
 matrix:
   include:
     - name: "Postgres 11"
+      env:
+        - PGDB=11
       addons:
         postgresql: "11"
         apt:
@@ -16,6 +18,8 @@ matrix:
             - postgresql-client-11
             - postgresql-11-postgis-2.5-scripts
     - name: "Postgres 10"
+      env:
+        - PGDB=10
       addons:
         postgresql: "10"
         apt:
@@ -35,6 +39,14 @@ services:
   - postgresql
 
 before_install:
+  - sudo -E service postgresql stop 9.2
+  - sudo -E service postgresql stop 9.3
+  - sudo -E service postgresql stop 9.4
+  - sudo -E service postgresql stop 9.5
+  - sudo -E service postgresql stop 9.6
+  - sudo -E sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo -E sed -i 's/port = 5433/port = 5432/' /etc/postgresql/*/main/postgresql.conf
+  - sudo -E service postgresql restart $PGDB
   - sudo mount -o remount,size=50% /var/ramfs
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
             - postgresql-11
             - postgresql-11-postgis-2.5
             - postgresql-client-11
+            - postgresql-11-postgis-2.5-scripts
     - name: "Postgres 10"
       addons:
         postgresql: "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ go:
 
 matrix:
   include:
+    - name: "Postgres 11"
+      addons:
+        postgresql: "11"
+        apt:
+          packages:
+            - postgresql-11
+            - postgresql-11-postgis-2.5
+            - postgresql-client-11
     - name: "Postgres 10"
       addons:
         postgresql: "10"


### PR DESCRIPTION
PG11 wouldn't start without the `postgres-11-postgis-2.5-scripts` package and this other hack: https://stackoverflow.com/questions/55161807/travis-ci-not-connecting-to-postgresql-11-2.

It looks like the tests themselves are failing with PG11, though. Unfortunately, I'm not familiar enough with Go or the test suite to understand if it's actually a problem or just an issue with the tests :(