### PR TITLE
Still do validation even when migrating to less than the current engine version

### DIFF
--- a/web/flow/flow_test.go
+++ b/web/flow/flow_test.go
@@ -46,8 +46,10 @@ func TestServer(t *testing.T) {
 		ResponsePattern string
 	}{
 		{URL: "/mr/flow/migrate", Method: "GET", Status: 405, Response: `{"error": "illegal method: GET"}`},
+		{URL: "/mr/flow/migrate", Method: "POST", BodyFile: "migrate_minimal_v13.json", Status: 200, ResponseFile: "migrate_minimal_v13.response.json"},
 		{URL: "/mr/flow/migrate", Method: "POST", BodyFile: "migrate_minimal_legacy.json", Status: 200, ResponseFile: "migrate_minimal_legacy.response.json"},
 		{URL: "/mr/flow/migrate", Method: "POST", BodyFile: "migrate_legacy_with_version.json", Status: 200, ResponseFile: "migrate_legacy_with_version.response.json"},
+		{URL: "/mr/flow/migrate", Method: "POST", BodyFile: "migrate_invalid_v13.json", Status: 422, Response: `{"error": "unable to read migrated flow: unable to read node: field 'uuid' is required"}`},
 
 		{URL: "/mr/flow/inspect", Method: "GET", Status: 405, Response: `{"error": "illegal method: GET"}`},
 		{URL: "/mr/flow/inspect", Method: "POST", BodyFile: "inspect_valid_legacy.json", Status: 200, ResponseFile: "inspect_valid_legacy.response.json"},

--- a/web/flow/testdata/migrate_invalid_v13.json
+++ b/web/flow/testdata/migrate_invalid_v13.json
@@ -1,0 +1,28 @@
+{
+    "flow": {
+        "uuid": "42362831-f376-4df1-b6d9-a80b102821d9",
+        "name": "Invalid Flow",
+        "revision": 1,
+        "spec_version": "13.0.0",
+        "type": "messaging",
+        "expire_after_minutes": 10080,
+        "language": "eng",
+        "localization": {},
+        "nodes": [
+            {
+                "actions": [
+                    {
+                        "text": "Hello world",
+                        "type": "send_msg",
+                        "uuid": "0aaa6871-15fb-408c-9f33-2d7d8f6d5baf"
+                    }
+                ],
+                "exits": [
+                    {
+                        "uuid": "40c6cb36-bb44-479a-8ed1-d3f8df3a134d"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/web/flow/testdata/migrate_minimal_v13.json
+++ b/web/flow/testdata/migrate_minimal_v13.json
@@ -1,0 +1,41 @@
+{
+    "flow": {
+        "uuid": "42362831-f376-4df1-b6d9-a80b102821d9",
+        "name": "Simple Flow",
+        "revision": 1,
+        "spec_version": "13.0.0",
+        "type": "messaging",
+        "expire_after_minutes": 10080,
+        "language": "eng",
+        "localization": {},
+        "nodes": [
+            {
+                "actions": [
+                    {
+                        "text": "Hello world",
+                        "type": "send_msg",
+                        "uuid": "0aaa6871-15fb-408c-9f33-2d7d8f6d5baf"
+                    }
+                ],
+                "exits": [
+                    {
+                        "uuid": "40c6cb36-bb44-479a-8ed1-d3f8df3a134d"
+                    }
+                ],
+                "uuid": "e41e7aad-de93-4cc0-ae56-d6af15ba1ac5"
+            }
+        ],
+        "_ui": {
+            "nodes": {
+                "e41e7aad-de93-4cc0-ae56-d6af15ba1ac5": {
+                    "position": {
+                        "left": 100,
+                        "top": 0
+                    },
+                    "type": "execute_actions"
+                }
+            },
+            "stickies": {}
+        }
+    }
+}

--- a/web/flow/testdata/migrate_minimal_v13.response.json
+++ b/web/flow/testdata/migrate_minimal_v13.response.json
@@ -1,0 +1,39 @@
+{
+    "uuid": "42362831-f376-4df1-b6d9-a80b102821d9",
+    "name": "Simple Flow",
+    "revision": 1,
+    "spec_version": "13.1.0",
+    "type": "messaging",
+    "expire_after_minutes": 10080,
+    "language": "eng",
+    "localization": {},
+    "nodes": [
+        {
+            "actions": [
+                {
+                    "text": "Hello world",
+                    "type": "send_msg",
+                    "uuid": "0aaa6871-15fb-408c-9f33-2d7d8f6d5baf"
+                }
+            ],
+            "exits": [
+                {
+                    "uuid": "40c6cb36-bb44-479a-8ed1-d3f8df3a134d"
+                }
+            ],
+            "uuid": "e41e7aad-de93-4cc0-ae56-d6af15ba1ac5"
+        }
+    ],
+    "_ui": {
+        "nodes": {
+            "e41e7aad-de93-4cc0-ae56-d6af15ba1ac5": {
+                "position": {
+                    "left": 100,
+                    "top": 0
+                },
+                "type": "execute_actions"
+            }
+        },
+        "stickies": {}
+    }
+}


### PR DESCRIPTION
Just realised we can still call `ReadFlow` so that we get structural validation. 

1. Do the JSON to JSON migration (e.g. 11.9 to 13.0.0)
2. Call ReadFlow on the migrated JSON which internally will migrate to 13.1.0 but that we don't return the result of that so it doesn't matter