### PR TITLE
Add endpoint to parse contactql query

### DIFF
--- a/models/contacts.go
+++ b/models/contacts.go
@@ -149,8 +149,8 @@ func ContactIDsFromReferences(ctx context.Context, tx Queryer, org *OrgAssets, r
 	return ids, nil
 }
 
-// buildFieldResolver builds a field resolver function for the passed in Org
-func buildFieldResolver(org *OrgAssets) contactql.FieldResolverFunc {
+// BuildFieldResolver builds a field resolver function for the passed in Org
+func BuildFieldResolver(org *OrgAssets) contactql.FieldResolverFunc {
 	return func(key string) assets.Field {
 		f := org.FieldByKey(key)
 		if f == nil {
@@ -186,7 +186,7 @@ func ContactIDsForQueryPage(ctx context.Context, client *elastic.Client, org *Or
 		return nil, nil, 0, errors.Errorf("no elastic client available, check your configuration")
 	}
 
-	resolver := buildFieldResolver(org)
+	resolver := BuildFieldResolver(org)
 
 	parsed, err := search.ParseQuery(org.Env(), resolver, query)
 	if err != nil {
@@ -248,7 +248,7 @@ func ContactIDsForQuery(ctx context.Context, client *elastic.Client, org *OrgAss
 	}
 
 	// turn into elastic query
-	resolver := buildFieldResolver(org)
+	resolver := BuildFieldResolver(org)
 	parsed, err := search.ParseQuery(org.Env(), resolver, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error parsing query: %s", query)

--- a/models/contacts_test.go
+++ b/models/contacts_test.go
@@ -48,9 +48,9 @@ func TestElasticContacts(t *testing.T) {
 						"must":[
 							{ "bool":{
 								"must":[
-									{"match":{"name":{"query":"george"}}},
 									{"term":{"org_id":1}},
-									{"term":{"is_active":true}}
+									{"term":{"is_active":true}},
+									{"match":{"name":{"query":"george"}}}
 								]
 							}},
 							{ "term":{
@@ -101,9 +101,9 @@ func TestElasticContacts(t *testing.T) {
 						"must":[
 							{"bool":
 								{"must":[
-									{"match":{"name":{"query":"nobody"}}},
 									{"term":{"org_id":1}},
-									{"term":{"is_active":true}}
+									{"term":{"is_active":true}},
+									{"match":{"name":{"query":"nobody"}}}
 								]}
 							},
 							{"term":{"is_blocked":false}},

--- a/search/search.go
+++ b/search/search.go
@@ -35,6 +35,10 @@ func ToElasticQuery(env envs.Environment, resolver contactql.FieldResolverFunc, 
 
 // FieldDependencies returns all the field this query is dependent on. This includes attributes such as "id" and "name"
 func FieldDependencies(query *contactql.ContactQuery) []string {
+	if query == nil {
+		return []string{}
+	}
+
 	seen := make(map[string]bool)
 	var appendFields func(node contactql.QueryNode, seen map[string]bool)
 	appendFields = func(node contactql.QueryNode, seen map[string]bool) {

--- a/web/contact/contact.go
+++ b/web/contact/contact.go
@@ -29,7 +29,7 @@ func init() {
 type searchRequest struct {
 	OrgID     models.OrgID     `json:"org_id"     validate:"required"`
 	GroupUUID assets.GroupUUID `json:"group_uuid" validate:"required"`
-	Query     string           `json:"query"      validate:"required"`
+	Query     string           `json:"query"`
 	PageSize  int              `json:"page_size"`
 	Offset    int              `json:"offset"`
 	Sort      string           `json:"sort"`
@@ -83,9 +83,15 @@ func handleSearch(ctx context.Context, s *web.Server, r *http.Request) (interfac
 		}
 	}
 
+	// create our normalized query
+	normalized := ""
+	if parsed != nil {
+		normalized = parsed.String()
+	}
+
 	// build our response
 	response := &searchResponse{
-		Query:      parsed.String(),
+		Query:      normalized,
 		ContactIDs: hits,
 		Fields:     search.FieldDependencies(parsed),
 		Total:      total,
@@ -144,9 +150,14 @@ func handleParseQuery(ctx context.Context, s *web.Server, r *http.Request) (inte
 		}
 	}
 
+	normalized := ""
+	if parsed != nil {
+		normalized = parsed.String()
+	}
+
 	// build our response
 	response := &parseResponse{
-		Query:  parsed.String(),
+		Query:  normalized,
 		Fields: search.FieldDependencies(parsed),
 	}
 

--- a/web/contact/contact_test.go
+++ b/web/contact/contact_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestServer(t *testing.T) {
+func TestSearch(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
 	db := testsuite.DB()
@@ -146,6 +146,75 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, tc.Hits, r.ContactIDs)
 			assert.Equal(t, tc.Query, r.Query)
 			assert.Equal(t, tc.Fields, r.Fields)
+		} else {
+			r := &web.ErrorResponse{}
+			err = json.Unmarshal(content, r)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Error, r.Error)
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	testsuite.Reset()
+	ctx := testsuite.CTX()
+	db := testsuite.DB()
+	rp := testsuite.RP()
+	wg := &sync.WaitGroup{}
+
+	server := web.NewServer(ctx, config.Mailroom, db, rp, nil, nil, wg)
+	server.Start()
+	time.Sleep(time.Second)
+
+	defer server.Stop()
+
+	tcs := []struct {
+		URL    string
+		Method string
+		Body   string
+		Status int
+		Error  string
+		Query  string
+		Fields []string
+	}{
+		{
+			"/mr/contact/parse_query", "GET",
+			"",
+			405, "illegal method: GET",
+			"", nil,
+		},
+		{
+			"/mr/contact/parse_query", "POST",
+			`{"org_id": 1, "query": "birthday = tomorrow"}`,
+			400, "can't resolve 'birthday' to attribute, scheme or field",
+			"", nil,
+		},
+		{
+			"/mr/contact/parse_query", "POST",
+			`{"org_id": 1, "query": "age > 10"}`,
+			200, "",
+			"age > 10", []string{"age"},
+		},
+	}
+
+	for i, tc := range tcs {
+		req, err := http.NewRequest(tc.Method, "http://localhost:8090"+tc.URL, bytes.NewReader([]byte(tc.Body)))
+		assert.NoError(t, err, "%d: error creating request", i)
+
+		resp, err := http.DefaultClient.Do(req)
+		assert.NoError(t, err, "%d: error making request", i)
+
+		assert.Equal(t, tc.Status, resp.StatusCode, "%d: unexpected status", i)
+
+		content, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err, "%d: error reading body", i)
+
+		// on 200 responses parse them
+		if resp.StatusCode == 200 {
+			r := &searchResponse{}
+			err = json.Unmarshal(content, r)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Query, r.Query)
 		} else {
 			r := &web.ErrorResponse{}
 			err = json.Unmarshal(content, r)

--- a/web/contact/contact_test.go
+++ b/web/contact/contact_test.go
@@ -117,6 +117,16 @@ func TestSearch(t *testing.T) {
 			[]string{"age", "gender"},
 			singleESResponse,
 		},
+		{
+			"/mr/contact/search", "POST",
+			fmt.Sprintf(`{"org_id": 1, "query": "", "group_uuid": "%s"}`, models.AllContactsGroupUUID),
+			200,
+			"",
+			[]models.ContactID{models.CathyID},
+			``,
+			[]string{},
+			singleESResponse,
+		},
 	}
 
 	for i, tc := range tcs {


### PR DESCRIPTION
Needed for validating queries for starts as well as for dynamic group editing.

Thought about getting cute and making this a `GET` operation on search (or maybe even `HEAD`) but that seems less clear.