### PR TITLE
allow globals with empty values

### DIFF
--- a/models/globals.go
+++ b/models/globals.go
@@ -16,7 +16,7 @@ type Global struct {
 	g struct {
 		Key   string `json:"key"   validate:"required"`
 		Name  string `json:"name"  validate:"required"`
-		Value string `json:"value" validate:"required"`
+		Value string `json:"value"`
 	}
 }
 

--- a/models/globals_test.go
+++ b/models/globals_test.go
@@ -11,6 +11,9 @@ func TestGlobals(t *testing.T) {
 	ctx := testsuite.CTX()
 	db := testsuite.DB()
 
+	// set one of our global values to empty
+	db.MustExec(`UPDATE globals_global SET value = '' WHERE org_id = $1 AND key = $2`, Org1, "org_name")
+
 	tx, err := db.BeginTxx(ctx, nil)
 	assert.NoError(t, err)
 	defer tx.Rollback()
@@ -24,5 +27,5 @@ func TestGlobals(t *testing.T) {
 	assert.Equal(t, "A213CD78", globals[0].Value())
 	assert.Equal(t, "org_name", globals[1].Key())
 	assert.Equal(t, "Org Name", globals[1].Name())
-	assert.Equal(t, "Nyaruka", globals[1].Value())
+	assert.Equal(t, "", globals[1].Value())
 }


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/nyaruka/issues/1511476599/?project=227973&referrer=alert_email

Looks like the view tries to prevent this, but since it isn't a DB constraint mailroom shouldn't blow up when it sees this.