### PR TITLE
💥 Fail flow starts which can't be started

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.10.0 // indirect
 	github.com/nyaruka/ezconf v0.2.1
 	github.com/nyaruka/gocommon v1.2.0
-	github.com/nyaruka/goflow v0.94.0
+	github.com/nyaruka/goflow v0.94.1
 	github.com/nyaruka/librato v1.0.0
 	github.com/nyaruka/logrus_sentry v0.8.2-0.20190129182604-c2962b80ba7d
 	github.com/nyaruka/null v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/nyaruka/gocommon v1.2.0 h1:gCmVCXYZFwKDMqQj8R1jNlK+7a06khKFq3zX8fBBbz
 github.com/nyaruka/gocommon v1.2.0/go.mod h1:9Y21Fd6iZXDLHWTRiZAc6b4LQSCi6HEEQK4SB45Yav4=
 github.com/nyaruka/goflow v0.94.0 h1:fmUdADrFsJjClsbxJMd0R0uMyYWtQNr4aiURBI31ZKo=
 github.com/nyaruka/goflow v0.94.0/go.mod h1:PDah2hr5WzODnUFK4VWWQkg7SqnYclf7P9Ik5u/VOG0=
+github.com/nyaruka/goflow v0.94.1 h1:FzbA4Age1i5GuQ9su/E4z7HRa7f5ghv+GeNGUn5nPfA=
+github.com/nyaruka/goflow v0.94.1/go.mod h1:PDah2hr5WzODnUFK4VWWQkg7SqnYclf7P9Ik5u/VOG0=
 github.com/nyaruka/librato v1.0.0 h1:Vznj9WCeC1yZXbBYyYp40KnbmXLbEkjKmHesV/v2SR0=
 github.com/nyaruka/librato v1.0.0/go.mod h1:pkRNLFhFurOz0QqBz6/DuTFhHHxAubWxs4Jx+J7yUgg=
 github.com/nyaruka/logrus_sentry v0.8.2-0.20190129182604-c2962b80ba7d h1:hyp9u36KIwbTCo2JAJ+TuJcJBc+UZzEig7RI/S5Dvkc=

--- a/models/starts.go
+++ b/models/starts.go
@@ -18,13 +18,26 @@ type StartID null.Int
 // NilStartID is our constant for a nil start id
 var NilStartID = StartID(0)
 
+// StartType is the type for the type of a start
 type StartType string
 
+// start type constants
 const (
 	StartTypeManual     = StartType("M")
 	StartTypeAPI        = StartType("A")
 	StartTypeFlowAction = StartType("F")
 	StartTypeTrigger    = StartType("T")
+)
+
+// StartStatus is the type for the status of a start
+type StartStatus string
+
+// start status constants
+const (
+	StartStatusPending  = StartStatus("P")
+	StartStatusStarting = StartStatus("S")
+	StartStatusComplete = StartStatus("C")
+	StartStatusFailed   = StartStatus("F")
 )
 
 // RestartParticipants is our type for the bool of restarting participatants
@@ -55,7 +68,15 @@ func MarkStartStarted(ctx context.Context, db *sqlx.DB, startID StartID, contact
 		return errors.Wrapf(err, "error setting start as started")
 	}
 	return nil
+}
 
+// MarkStartFailed sets the status for the passed in flow start to F
+func MarkStartFailed(ctx context.Context, db *sqlx.DB, startID StartID) error {
+	_, err := db.Exec("UPDATE flows_flowstart SET status = 'F', modified_on = NOW() WHERE id = $1", startID)
+	if err != nil {
+		return errors.Wrapf(err, "error setting start as failed")
+	}
+	return nil
 }
 
 // FlowStartBatch represents a single flow batch that needs to be started

--- a/web/contact/contact.go
+++ b/web/contact/contact.go
@@ -89,12 +89,11 @@ func handleSearch(ctx context.Context, s *web.Server, r *http.Request) (interfac
 		request.GroupUUID, request.Query, request.Sort, request.Offset, request.PageSize)
 
 	if err != nil {
-		switch cause := errors.Cause(err).(type) {
-		case *contactql.QueryError:
-			return cause, http.StatusBadRequest, nil
-		default:
-			return nil, http.StatusInternalServerError, err
+		isQueryError, qerr := contactql.IsQueryError(err)
+		if isQueryError {
+			return qerr, http.StatusBadRequest, nil
 		}
+		return nil, http.StatusInternalServerError, err
 	}
 
 	// normalize and inspect the query
@@ -181,12 +180,11 @@ func handleParseQuery(ctx context.Context, s *web.Server, r *http.Request) (inte
 	parsed, err := contactql.ParseQuery(request.Query, env.RedactionPolicy(), env.DefaultCountry(), org.SessionAssets())
 
 	if err != nil {
-		switch cause := errors.Cause(err).(type) {
-		case *contactql.QueryError:
-			return cause, http.StatusBadRequest, nil
-		default:
-			return nil, http.StatusInternalServerError, err
+		isQueryError, qerr := contactql.IsQueryError(err)
+		if isQueryError {
+			return qerr, http.StatusBadRequest, nil
 		}
+		return nil, http.StatusInternalServerError, err
 	}
 
 	// normalize and inspect the query


### PR DESCRIPTION
Started off looking at https://sentry.io/organizations/nyaruka/issues/1756193944/?project=1281372&referrer=alert_email and wondering if invalid search queries could stay out of Sentry, but then noticed that we don't mark starts as failed when the handler task errors... or at least I'm not seeing any code anywhere which marks starts as failed.
