### PR TITLE
🙈 Ignore missing assets when reading modifiers

### DIFF
--- a/web/contact/contact.go
+++ b/web/contact/contact.go
@@ -290,7 +290,7 @@ func handleModify(ctx context.Context, s *web.Server, r *http.Request) (interfac
 	// build up our modifiers
 	mods := make([]flows.Modifier, len(request.Modifiers))
 	for i, m := range request.Modifiers {
-		mod, err := modifiers.ReadModifier(org.SessionAssets(), m, nil)
+		mod, err := modifiers.ReadModifier(org.SessionAssets(), m, assets.IgnoreMissing)
 		if err != nil {
 			return errors.Wrapf(err, "error in modifier: %s", string(m)), http.StatusBadRequest, nil
 		}


### PR DESCRIPTION
https://sentry.io/organizations/nyaruka/issues/1756312415/?project=1285856&referrer=alert_email

This is a groups modifier (sent to the contact modify endpoint) which references a non-existent group.. still investigating what could have led to this