### PR TITLE
🧹 Pass orgID from the base task to task structs 

### DIFF
--- a/tasks/base.go
+++ b/tasks/base.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom"
+	"github.com/nyaruka/mailroom/models"
 	"github.com/nyaruka/mailroom/queue"
 
 	"github.com/pkg/errors"
@@ -28,7 +29,7 @@ func RegisterType(name string, initFunc func() Task) {
 		ctx, cancel := context.WithTimeout(ctx, typedTask.Timeout())
 		defer cancel()
 
-		return typedTask.Perform(ctx, mr)
+		return typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
 	})
 }
 
@@ -38,7 +39,7 @@ type Task interface {
 	Timeout() time.Duration
 
 	// Perform performs the task
-	Perform(ctx context.Context, mr *mailroom.Mailroom) error
+	Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error
 }
 
 //------------------------------------------------------------------------------------------

--- a/tasks/base_test.go
+++ b/tasks/base_test.go
@@ -13,14 +13,12 @@ import (
 
 func TestReadTask(t *testing.T) {
 	task, err := tasks.ReadTask("populate_dynamic_group", []byte(`{
-		"org_id": 2,
 		"group_id": 23,
 		"query": "gender = F"
 	}`))
 	require.NoError(t, err)
 
 	typedTask := task.(*groups.PopulateDynamicGroupTask)
-	assert.Equal(t, models.OrgID(2), typedTask.OrgID)
 	assert.Equal(t, models.GroupID(23), typedTask.GroupID)
 	assert.Equal(t, "gender = F", typedTask.Query)
 }

--- a/tasks/campaigns/cron_test.go
+++ b/tasks/campaigns/cron_test.go
@@ -44,7 +44,7 @@ func TestCampaigns(t *testing.T) {
 	require.NoError(t, err)
 
 	// work on that task
-	err = typedTask.Perform(ctx, mr)
+	err = typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
 	assert.NoError(t, err)
 
 	// should now have a flow run for that contact and flow
@@ -81,7 +81,7 @@ func TestIVRCampaigns(t *testing.T) {
 	require.NoError(t, err)
 
 	// work on that task
-	err = typedTask.Perform(ctx, mr)
+	err = typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
 	assert.NoError(t, err)
 
 	// should now have a flow start created

--- a/tasks/campaigns/fire_campaign_event.go
+++ b/tasks/campaigns/fire_campaign_event.go
@@ -32,7 +32,6 @@ type FireCampaignEventTask struct {
 	FlowUUID     assets.FlowUUID `json:"flow_uuid"`
 	CampaignUUID string          `json:"campaign_uuid"`
 	CampaignName string          `json:"campaign_name"`
-	OrgID        models.OrgID    `json:"org_id"`
 }
 
 // Timeout is the maximum amount of time the task can run for
@@ -47,7 +46,7 @@ func (t *FireCampaignEventTask) Timeout() time.Duration {
 //   - creates the trigger for that event
 //   - runs the flow that is to be started through our engine
 //   - saves the flow run and session resulting from our run
-func (t *FireCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom) error {
+func (t *FireCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
 	db := mr.DB
 	rp := mr.RP
 	log := logrus.WithField("comp", "campaign_worker").WithField("event_id", t.EventID)
@@ -82,7 +81,7 @@ func (t *FireCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailro
 
 	campaign := triggers.NewCampaignReference(triggers.CampaignUUID(t.CampaignUUID), t.CampaignName)
 
-	started, err := runner.FireCampaignEvents(ctx, db, rp, t.OrgID, fires, t.FlowUUID, campaign, triggers.CampaignEventUUID(t.EventUUID))
+	started, err := runner.FireCampaignEvents(ctx, db, rp, orgID, fires, t.FlowUUID, campaign, triggers.CampaignEventUUID(t.EventUUID))
 
 	// remove all the contacts that were started
 	for _, contactID := range started {

--- a/tasks/campaigns/schedule_campaign_event.go
+++ b/tasks/campaigns/schedule_campaign_event.go
@@ -24,7 +24,6 @@ func init() {
 
 // ScheduleCampaignEventTask is our definition of our event recalculation task
 type ScheduleCampaignEventTask struct {
-	OrgID           models.OrgID           `json:"org_id"`
 	CampaignEventID models.CampaignEventID `json:"campaign_event_id"`
 }
 
@@ -34,7 +33,7 @@ func (t *ScheduleCampaignEventTask) Timeout() time.Duration {
 }
 
 // Perform creates the actual event fires to schedule the given campaign event
-func (t *ScheduleCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom) error {
+func (t *ScheduleCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
 	db := mr.DB
 	rp := mr.RP
 	lockKey := fmt.Sprintf(scheduleLockKey, t.CampaignEventID)
@@ -45,7 +44,7 @@ func (t *ScheduleCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Ma
 	}
 	defer locker.ReleaseLock(rp, lockKey, lock)
 
-	err = models.ScheduleCampaignEvent(ctx, db, t.OrgID, t.CampaignEventID)
+	err = models.ScheduleCampaignEvent(ctx, db, orgID, t.CampaignEventID)
 	if err != nil {
 		return errors.Wrapf(err, "error scheduling campaign event %d", t.CampaignEventID)
 	}

--- a/tasks/campaigns/schedule_campaign_event_test.go
+++ b/tasks/campaigns/schedule_campaign_event_test.go
@@ -42,8 +42,8 @@ func TestScheduleCampaignEvent(t *testing.T) {
 	//  2. +10 Minutes send message
 
 	// schedule first event...
-	task := &campaigns.ScheduleCampaignEventTask{OrgID: models.Org1, CampaignEventID: models.RemindersEvent1ID}
-	err := task.Perform(ctx, mr)
+	task := &campaigns.ScheduleCampaignEventTask{CampaignEventID: models.RemindersEvent1ID}
+	err := task.Perform(ctx, mr, models.Org1)
 	require.NoError(t, err)
 
 	// cathy has no value for joined and alexandia has a value too far in past, but bob and george will have values...
@@ -53,8 +53,8 @@ func TestScheduleCampaignEvent(t *testing.T) {
 	})
 
 	// schedule second event...
-	task = &campaigns.ScheduleCampaignEventTask{OrgID: models.Org1, CampaignEventID: models.RemindersEvent2ID}
-	err = task.Perform(ctx, mr)
+	task = &campaigns.ScheduleCampaignEventTask{CampaignEventID: models.RemindersEvent2ID}
+	err = task.Perform(ctx, mr, models.Org1)
 	require.NoError(t, err)
 
 	assertContactFires(t, models.RemindersEvent2ID, map[models.ContactID]time.Time{
@@ -77,8 +77,8 @@ func TestScheduleCampaignEvent(t *testing.T) {
 	// create new campaign event based on created_on + 5 minutes
 	event3 := insertCampaignEvent(t, models.DoctorRemindersCampaignID, models.FavoritesFlowID, models.CreatedOnFieldID, 5, "M")
 
-	task = &campaigns.ScheduleCampaignEventTask{OrgID: models.Org1, CampaignEventID: event3}
-	err = task.Perform(ctx, mr)
+	task = &campaigns.ScheduleCampaignEventTask{CampaignEventID: event3}
+	err = task.Perform(ctx, mr, models.Org1)
 	require.NoError(t, err)
 
 	// only cathy is in the group and new enough to have a fire
@@ -92,8 +92,8 @@ func TestScheduleCampaignEvent(t *testing.T) {
 	// bump last_seen_on for bob
 	db.MustExec(`UPDATE contacts_contact SET last_seen_on = '2040-01-01T00:00:00Z' WHERE id = $1`, models.BobID)
 
-	task = &campaigns.ScheduleCampaignEventTask{OrgID: models.Org1, CampaignEventID: event4}
-	err = task.Perform(ctx, mr)
+	task = &campaigns.ScheduleCampaignEventTask{CampaignEventID: event4}
+	err = task.Perform(ctx, mr, models.Org1)
 	require.NoError(t, err)
 
 	assertContactFires(t, event4, map[models.ContactID]time.Time{

--- a/tasks/groups/populate_dynamic_group.go
+++ b/tasks/groups/populate_dynamic_group.go
@@ -25,7 +25,6 @@ func init() {
 
 // PopulateDynamicGroupTask is our task to populate the contacts for a dynamic group
 type PopulateDynamicGroupTask struct {
-	OrgID   models.OrgID   `json:"org_id"`
 	GroupID models.GroupID `json:"group_id"`
 	Query   string         `json:"query"`
 }
@@ -36,7 +35,7 @@ func (t *PopulateDynamicGroupTask) Timeout() time.Duration {
 }
 
 // Perform figures out the membership for a query based group then repopulates it
-func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, mr *mailroom.Mailroom) error {
+func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
 	lockKey := fmt.Sprintf(populateLockKey, t.GroupID)
 	lock, err := locker.GrabLock(mr.RP, lockKey, time.Hour, time.Minute*5)
 	if err != nil {
@@ -47,13 +46,13 @@ func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, mr *mailroom.Mai
 	start := time.Now()
 	log := logrus.WithFields(logrus.Fields{
 		"group_id": t.GroupID,
-		"org_id":   t.OrgID,
+		"org_id":   orgID,
 		"query":    t.Query,
 	})
 
 	log.Info("starting population of dynamic group")
 
-	oa, err := models.GetOrgAssets(ctx, mr.DB, t.OrgID)
+	oa, err := models.GetOrgAssets(ctx, mr.DB, orgID)
 	if err != nil {
 		return errors.Wrapf(err, "unable to load org when populating group: %d", t.GroupID)
 	}

--- a/tasks/groups/populate_dynamic_group_test.go
+++ b/tasks/groups/populate_dynamic_group_test.go
@@ -67,11 +67,10 @@ func TestPopulateTask(t *testing.T) {
 	require.NoError(t, err)
 
 	task := &groups.PopulateDynamicGroupTask{
-		OrgID:   models.Org1,
 		GroupID: groupID,
 		Query:   "gender = F",
 	}
-	err = task.Perform(ctx, mr)
+	err = task.Perform(ctx, mr, models.Org1)
 	require.NoError(t, err)
 
 	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM contacts_contactgroup_contacts WHERE contactgroup_id = $1`, []interface{}{groupID}, 1)

--- a/tasks/interrupts/interrupt_sessions.go
+++ b/tasks/interrupts/interrupt_sessions.go
@@ -63,7 +63,7 @@ func (t *InterruptSessionsTask) Timeout() time.Duration {
 	return time.Hour
 }
 
-func (t *InterruptSessionsTask) Perform(ctx context.Context, mr *mailroom.Mailroom) error {
+func (t *InterruptSessionsTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
 	db := mr.DB
 
 	sessionIDs := make(map[models.SessionID]bool)

--- a/tasks/interrupts/interrupt_sessions_test.go
+++ b/tasks/interrupts/interrupt_sessions_test.go
@@ -105,7 +105,7 @@ func TestInterrupts(t *testing.T) {
 		}
 
 		// execute it
-		err := task.Perform(ctx, mr)
+		err := task.Perform(ctx, mr, models.Org1)
 		assert.NoError(t, err)
 
 		// check session statuses are as expected


### PR DESCRIPTION
To remove need for duplicating it in the task "body" - some of our tasks have ended up with org being included twice in their overall payload. I think this might have been me forgetting that I could get org from the container task so some of the tasks look like...

```json
{
  "type": "schedule_campaign_event",
  "org_id": 123,
  "task": {"org_id": 123, "campaign_event_id": 3456},
  "queued_on": "2020-09-22T10:15:30Z",
}
```