### PR TITLE
Don't write to flows_flowrun.timeout_on so it can be dropped

### DIFF
--- a/core/models/runs.go
+++ b/core/models/runs.go
@@ -936,7 +936,6 @@ SET
 	exit_type = $2,
 	exited_on = $3,
 	status = $4,
-	timeout_on = NULL,
 	modified_on = NOW()
 WHERE
 	id = ANY (SELECT id FROM flows_flowrun WHERE session_id = ANY($1) AND is_active = TRUE)


### PR DESCRIPTION
Tis not used