### PR TITLE
🥬 Ensure field and group assets used for imports are fresh

### DIFF
--- a/core/models/imports.go
+++ b/core/models/imports.go
@@ -82,7 +82,7 @@ func (b *ContactImportBatch) tryImport(ctx context.Context, db *sqlx.DB, orgID O
 	}
 
 	// grab our org assets
-	oa, err := GetOrgAssets(ctx, db, orgID)
+	oa, err := GetOrgAssetsWithRefresh(ctx, db, orgID, RefreshFields|RefreshGroups)
 	if err != nil {
 		return errors.Wrap(err, "error loading org assets")
 	}


### PR DESCRIPTION
Looks like an import didn't quite work as intended because it didn't see the group that RP had just created