### PR TITLE
Variable timeout for fire campaign task

### DIFF
--- a/core/tasks/campaigns/fire_campaign_event.go
+++ b/core/tasks/campaigns/fire_campaign_event.go
@@ -36,7 +36,8 @@ type FireCampaignEventTask struct {
 
 // Timeout is the maximum amount of time the task can run for
 func (t *FireCampaignEventTask) Timeout() time.Duration {
-	return time.Minute * 5
+	// base of 5 minutes + one minute per fire
+	return time.Minute*5 + time.Minute*time.Duration(len(t.FireIDs))
 }
 
 // Perform handles firing campaign events


### PR DESCRIPTION
Should help with flow starts that have timing out webhooks