### PR TITLE
🧯 Fix updating message status when id column is bigint

### DIFF
--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/nyaruka/null"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/lib/pq/hstore"
 	"github.com/pkg/errors"
@@ -460,17 +459,17 @@ func UpdateMessage(ctx context.Context, tx Queryer, msgID flows.MsgID, status Ms
 }
 
 // MarkMessagesPending marks the passed in messages as pending
-func MarkMessagesPending(ctx context.Context, tx *sqlx.Tx, msgs []*Msg) error {
-	return updateMessageStatus(ctx, tx, msgs, MsgStatusPending)
+func MarkMessagesPending(ctx context.Context, db Queryer, msgs []*Msg) error {
+	return updateMessageStatus(ctx, db, msgs, MsgStatusPending)
 }
 
 // MarkMessagesQueued marks the passed in messages as queued
-func MarkMessagesQueued(ctx context.Context, tx *sqlx.Tx, msgs []*Msg) error {
-	return updateMessageStatus(ctx, tx, msgs, MsgStatusQueued)
+func MarkMessagesQueued(ctx context.Context, db Queryer, msgs []*Msg) error {
+	return updateMessageStatus(ctx, db, msgs, MsgStatusQueued)
 }
 
 // MarkMessagesQueued marks the passed in messages as queued
-func updateMessageStatus(ctx context.Context, tx *sqlx.Tx, msgs []*Msg, status MsgStatus) error {
+func updateMessageStatus(ctx context.Context, db Queryer, msgs []*Msg, status MsgStatus) error {
 	is := make([]interface{}, len(msgs))
 	for i, msg := range msgs {
 		m := &msg.m
@@ -478,7 +477,7 @@ func updateMessageStatus(ctx context.Context, tx *sqlx.Tx, msgs []*Msg, status M
 		is[i] = m
 	}
 
-	return BulkQuery(ctx, "updating message status", tx, updateMsgStatusSQL, is)
+	return BulkQuery(ctx, "updating message status", db, updateMsgStatusSQL, is)
 }
 
 const updateMsgStatusSQL = `
@@ -491,7 +490,7 @@ FROM (
 ) AS
 	m(id, status)
 WHERE
-	msgs_msg.id = m.id::int
+	msgs_msg.id = m.id::bigint
 `
 
 // GetMessageIDFromUUID gets the ID of a message from its UUID

--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -463,12 +463,6 @@ func MarkMessagesPending(ctx context.Context, db Queryer, msgs []*Msg) error {
 	return updateMessageStatus(ctx, db, msgs, MsgStatusPending)
 }
 
-// MarkMessagesQueued marks the passed in messages as queued
-func MarkMessagesQueued(ctx context.Context, db Queryer, msgs []*Msg) error {
-	return updateMessageStatus(ctx, db, msgs, MsgStatusQueued)
-}
-
-// MarkMessagesQueued marks the passed in messages as queued
 func updateMessageStatus(ctx context.Context, db Queryer, msgs []*Msg, status MsgStatus) error {
 	is := make([]interface{}, len(msgs))
 	for i, msg := range msgs {

--- a/core/models/msgs_test.go
+++ b/core/models/msgs_test.go
@@ -190,16 +190,11 @@ func TestMarkMessages(t *testing.T) {
 
 	msg1 := insertMsg("Hello")
 	msg2 := insertMsg("Hola")
-	msg3 := insertMsg("Howdy")
+	insertMsg("Howdy")
 
 	models.MarkMessagesPending(ctx, db, []*models.Msg{msg1, msg2})
 
 	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 2)
-
-	models.MarkMessagesQueued(ctx, db, []*models.Msg{msg1, msg3})
-
-	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 1)
-	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'Q'`, nil, 2)
 
 	// try running on database with BIGINT message ids
 	db.MustExec(`ALTER TABLE "msgs_msg" ALTER COLUMN "id" TYPE bigint USING "id"::bigint;`)
@@ -213,5 +208,5 @@ func TestMarkMessages(t *testing.T) {
 	err = models.MarkMessagesPending(ctx, db, []*models.Msg{msg4})
 	assert.NoError(t, err)
 
-	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 2)
+	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 3)
 }

--- a/core/models/msgs_test.go
+++ b/core/models/msgs_test.go
@@ -166,3 +166,52 @@ func TestNormalizeAttachment(t *testing.T) {
 		assert.Equal(t, tc.normalized, string(models.NormalizeAttachment(utils.Attachment(tc.raw))))
 	}
 }
+
+func TestMarkMessages(t *testing.T) {
+	ctx, db, _ := testsuite.Reset()
+	defer testsuite.Reset()
+
+	oa, err := models.GetOrgAssetsWithRefresh(ctx, db, models.Org1, models.RefreshOrg)
+	require.NoError(t, err)
+
+	channel := oa.ChannelByUUID(models.TwilioChannelUUID)
+
+	insertMsg := func(text string) *models.Msg {
+		urn := urns.URN(fmt.Sprintf("tel:+250700000001?id=%d", models.CathyURNID))
+		flowMsg := flows.NewMsgOut(urn, channel.ChannelReference(), text, nil, nil, nil, flows.NilMsgTopic)
+		msg, err := models.NewOutgoingMsg(oa.Org(), channel, models.CathyID, flowMsg, time.Now())
+		require.NoError(t, err)
+
+		err = models.InsertMessages(ctx, db, []*models.Msg{msg})
+		require.NoError(t, err)
+
+		return msg
+	}
+
+	msg1 := insertMsg("Hello")
+	msg2 := insertMsg("Hola")
+	msg3 := insertMsg("Howdy")
+
+	models.MarkMessagesPending(ctx, db, []*models.Msg{msg1, msg2})
+
+	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 2)
+
+	models.MarkMessagesQueued(ctx, db, []*models.Msg{msg1, msg3})
+
+	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 1)
+	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'Q'`, nil, 2)
+
+	// try running on database with BIGINT message ids
+	db.MustExec(`ALTER TABLE "msgs_msg" ALTER COLUMN "id" TYPE bigint USING "id"::bigint;`)
+	db.MustExec(`ALTER SEQUENCE "msgs_msg_id_seq" AS bigint;`)
+	db.MustExec(`ALTER SEQUENCE "msgs_msg_id_seq" RESTART WITH 3000000000;`)
+	db = testsuite.DB() // need new connection after changes
+
+	msg4 := insertMsg("Big messages!")
+	assert.Equal(t, flows.MsgID(3000000000), msg4.ID())
+
+	err = models.MarkMessagesPending(ctx, db, []*models.Msg{msg4})
+	assert.NoError(t, err)
+
+	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'P'`, nil, 2)
+}


### PR DESCRIPTION
I don't think mailroom commonly updates message status thus why we haven't seen this in sentry. It's only when queuing flow messages to courier fails, or receiving channel-less messages, that we put the failed messages into status PENDING.