### PR TITLE
Rename tickets/internal package

### DIFF
--- a/cmd/mailroom/main.go
+++ b/cmd/mailroom/main.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/nyaruka/mailroom/core/tasks/starts"
 	_ "github.com/nyaruka/mailroom/core/tasks/stats"
 	_ "github.com/nyaruka/mailroom/core/tasks/timeouts"
+	_ "github.com/nyaruka/mailroom/services/tickets/intern"
 	_ "github.com/nyaruka/mailroom/services/tickets/mailgun"
 	_ "github.com/nyaruka/mailroom/services/tickets/rocketchat"
 	_ "github.com/nyaruka/mailroom/services/tickets/zendesk"

--- a/services/tickets/intern/service.go
+++ b/services/tickets/intern/service.go
@@ -1,4 +1,4 @@
-package internal
+package intern
 
 import (
 	"net/http"

--- a/services/tickets/intern/service_test.go
+++ b/services/tickets/intern/service_test.go
@@ -1,4 +1,4 @@
-package internal_test
+package intern_test
 
 import (
 	"net/http"
@@ -12,7 +12,7 @@ import (
 	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
-	"github.com/nyaruka/mailroom/services/tickets/internal"
+	intern "github.com/nyaruka/mailroom/services/tickets/intern"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,7 @@ func TestOpenAndForward(t *testing.T) {
 
 	ticketer := flows.NewTicketer(types.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "internal"))
 
-	svc, err := internal.NewService(
+	svc, err := intern.NewService(
 		http.DefaultClient,
 		nil,
 		ticketer,
@@ -70,7 +70,7 @@ func TestCloseAndReopen(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 
 	ticketer := flows.NewTicketer(types.NewTicketer(assets.TicketerUUID(uuids.New()), "Support", "mailgun"))
-	svc, err := internal.NewService(http.DefaultClient, nil, ticketer, nil)
+	svc, err := intern.NewService(http.DefaultClient, nil, ticketer, nil)
 	require.NoError(t, err)
 
 	logger := &flows.HTTPLogger{}


### PR DESCRIPTION
Don't really want to rename our concept of an internal ticketer just because of a golang quirk.. so just renaming the package a little to fix #408 