### PR TITLE
Fail expirations that are no longer the active session

### DIFF
--- a/core/models/runs.go
+++ b/core/models/runs.go
@@ -78,12 +78,14 @@ var exitToSessionStatusMap = map[ExitType]SessionStatus{
 	ExitInterrupted: SessionStatusInterrupted,
 	ExitCompleted:   SessionStatusCompleted,
 	ExitExpired:     SessionStatusExpired,
+	ExitFailed:      SessionStatusFailed,
 }
 
 var exitToRunStatusMap = map[ExitType]RunStatus{
 	ExitInterrupted: RunStatusInterrupted,
 	ExitCompleted:   RunStatusCompleted,
 	ExitExpired:     RunStatusExpired,
+	ExitFailed:      RunStatusFailed,
 }
 
 var keptEvents = map[string]bool{
@@ -953,7 +955,8 @@ SET
 	ended_on = $2,
 	status = $3
 WHERE
-	id = ANY ($1)
+	id = ANY ($1) AND
+	status = 'W'
 `
 
 // InterruptContactRuns interrupts all runs and sesions that exist for the passed in list of contacts

--- a/core/runner/runner.go
+++ b/core/runner/runner.go
@@ -72,7 +72,7 @@ func ResumeFlow(ctx context.Context, db *sqlx.DB, rp *redis.Pool, oa *models.Org
 		// if this flow just isn't available anymore, log this error
 		if err == models.ErrNotFound {
 			logrus.WithField("contact_uuid", session.Contact().UUID()).WithField("session_id", session.ID()).WithField("flow_id", session.CurrentFlowID()).Error("unable to find flow in resume")
-			return nil, models.ExitSessions(ctx, db, []models.SessionID{session.ID()}, models.ExitInterrupted, time.Now())
+			return nil, models.ExitSessions(ctx, db, []models.SessionID{session.ID()}, models.ExitFailed, time.Now())
 		}
 		return nil, errors.Wrapf(err, "error loading session flow: %d", session.CurrentFlowID())
 	}


### PR DESCRIPTION
This update has us fail the runs and sessions that are expired when there is a newer active session. Technically this shouldn't occur, so we log an error, but we may as well fail the old run and session while we are at it and perhaps we can start seeing patterns when this occurs to track down the possible race causing these to occur. (we have a few dozen in total on TextIt)

Note this does introduce us using the FAILED status on session and run, which we previously weren't using. I feel this is a more accurate status than say "interrupted", which we have used previous for cases like this. Another similar case is a flow resuming for a flow that has been deleted. Previously we were updating the run and session to interrupted in those cases, but FAILED seems more right to me? Totally open to discussion there.