### PR TITLE
introduce runtime, move Server to use it

### DIFF
--- a/core/models/tickets.go
+++ b/core/models/tickets.go
@@ -203,7 +203,7 @@ WHERE
 `
 
 // LookupTicketByUUID looks up the ticket with the passed in UUID
-func LookupTicketByUUID(ctx context.Context, db Queryer, uuid flows.TicketUUID) (*Ticket, error) {
+func LookupTicketByUUID(ctx context.Context, db *sqlx.DB, uuid flows.TicketUUID) (*Ticket, error) {
 	return lookupTicket(ctx, db, selectTicketByUUIDSQL, uuid)
 }
 

--- a/core/models/tickets_test.go
+++ b/core/models/tickets_test.go
@@ -56,7 +56,8 @@ func TestTicketers(t *testing.T) {
 
 func TestTickets(t *testing.T) {
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
+	rt := testsuite.Runtime()
+	db := rt.DB
 
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 

--- a/core/models/tickets_test.go
+++ b/core/models/tickets_test.go
@@ -56,7 +56,7 @@ func TestTicketers(t *testing.T) {
 
 func TestTickets(t *testing.T) {
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 
 	defer httpx.SetRequestor(httpx.DefaultRequestor)

--- a/core/tasks/base.go
+++ b/core/tasks/base.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 
 	"github.com/pkg/errors"
 )
@@ -19,7 +20,7 @@ var registeredTypes = map[string](func() Task){}
 func RegisterType(name string, initFunc func() Task) {
 	registeredTypes[name] = initFunc
 
-	mailroom.AddTaskFunction(name, func(ctx context.Context, mr *mailroom.Mailroom, task *queue.Task) error {
+	mailroom.AddTaskFunction(name, func(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error {
 		// decode our task body
 		typedTask, err := ReadTask(task.Type, task.Task)
 		if err != nil {
@@ -29,7 +30,7 @@ func RegisterType(name string, initFunc func() Task) {
 		ctx, cancel := context.WithTimeout(ctx, typedTask.Timeout())
 		defer cancel()
 
-		return typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
+		return typedTask.Perform(ctx, rt, models.OrgID(task.OrgID))
 	})
 }
 
@@ -39,7 +40,7 @@ type Task interface {
 	Timeout() time.Duration
 
 	// Perform performs the task
-	Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error
+	Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error
 }
 
 //------------------------------------------------------------------------------------------

--- a/core/tasks/broadcasts/worker.go
+++ b/core/tasks/broadcasts/worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/msgio"
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -26,7 +27,7 @@ func init() {
 }
 
 // handleSendBroadcast creates all the batches of contacts that need to be sent to
-func handleSendBroadcast(ctx context.Context, mr *mailroom.Mailroom, task *queue.Task) error {
+func handleSendBroadcast(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
 	defer cancel()
 
@@ -40,7 +41,7 @@ func handleSendBroadcast(ctx context.Context, mr *mailroom.Mailroom, task *queue
 		return errors.Wrapf(err, "error unmarshalling broadcast: %s", string(task.Task))
 	}
 
-	return CreateBroadcastBatches(ctx, mr.DB, mr.RP, broadcast)
+	return CreateBroadcastBatches(ctx, rt.DB, rt.RP, broadcast)
 }
 
 // CreateBroadcastBatches takes our master broadcast and creates batches of broadcast sends for all the unique contacts
@@ -130,7 +131,7 @@ func CreateBroadcastBatches(ctx context.Context, db *sqlx.DB, rp *redis.Pool, bc
 }
 
 // handleSendBroadcastBatch sends our messages
-func handleSendBroadcastBatch(ctx context.Context, mr *mailroom.Mailroom, task *queue.Task) error {
+func handleSendBroadcastBatch(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*60)
 	defer cancel()
 
@@ -145,7 +146,7 @@ func handleSendBroadcastBatch(ctx context.Context, mr *mailroom.Mailroom, task *
 	}
 
 	// try to send the batch
-	return SendBroadcastBatch(ctx, mr.DB, mr.RP, broadcast)
+	return SendBroadcastBatch(ctx, rt.DB, rt.RP, broadcast)
 }
 
 // SendBroadcastBatch sends the passed in broadcast batch

--- a/core/tasks/campaigns/cron_test.go
+++ b/core/tasks/campaigns/cron_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nyaruka/mailroom"
-	"github.com/nyaruka/mailroom/config"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/queue"
@@ -20,20 +18,18 @@ import (
 func TestCampaigns(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
-	rp := testsuite.RP()
+
+	rt := testsuite.Runtime()
 	rc := testsuite.RC()
 	defer rc.Close()
 
-	mr := &mailroom.Mailroom{Config: config.Mailroom, DB: db, RP: testsuite.RP(), ElasticClient: nil}
-
 	// let's create a campaign event fire for one of our contacts (for now this is totally hacked, they aren't in the group and
 	// their relative to date isn't relative, but this still tests execution)
-	db.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, testdata.Cathy.ID, testdata.George.ID, testdata.RemindersEvent1.ID)
+	rt.DB.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, testdata.Cathy.ID, testdata.George.ID, testdata.RemindersEvent1.ID)
 	time.Sleep(10 * time.Millisecond)
 
 	// schedule our campaign to be started
-	err := fireCampaignEvents(ctx, db, rp, campaignsLock, "lock")
+	err := fireCampaignEvents(ctx, rt.DB, rt.RP, campaignsLock, "lock")
 	assert.NoError(t, err)
 
 	// then actually work on the event
@@ -45,32 +41,30 @@ func TestCampaigns(t *testing.T) {
 	require.NoError(t, err)
 
 	// work on that task
-	err = typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
+	err = typedTask.Perform(ctx, rt, models.OrgID(task.OrgID))
 	assert.NoError(t, err)
 
 	// should now have a flow run for that contact and flow
-	testsuite.AssertQueryCount(t, db, `SELECT COUNT(*) from flows_flowrun WHERE contact_id = $1 AND flow_id = $2;`, []interface{}{testdata.Cathy.ID, testdata.Favorites.ID}, 1)
-	testsuite.AssertQueryCount(t, db, `SELECT COUNT(*) from flows_flowrun WHERE contact_id = $1 AND flow_id = $2;`, []interface{}{testdata.George.ID, testdata.Favorites.ID}, 1)
+	testsuite.AssertQueryCount(t, rt.DB, `SELECT COUNT(*) from flows_flowrun WHERE contact_id = $1 AND flow_id = $2;`, []interface{}{testdata.Cathy.ID, testdata.Favorites.ID}, 1)
+	testsuite.AssertQueryCount(t, rt.DB, `SELECT COUNT(*) from flows_flowrun WHERE contact_id = $1 AND flow_id = $2;`, []interface{}{testdata.George.ID, testdata.Favorites.ID}, 1)
 }
 
 func TestIVRCampaigns(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
-	rp := testsuite.RP()
+	rt := testsuite.Runtime()
+	db := rt.DB
 	rc := testsuite.RC()
 	defer rc.Close()
 
-	mr := &mailroom.Mailroom{Config: config.Mailroom, DB: db, RP: testsuite.RP(), ElasticClient: nil}
-
 	// let's create a campaign event fire for one of our contacts (for now this is totally hacked, they aren't in the group and
 	// their relative to date isn't relative, but this still tests execution)
-	db.MustExec(`UPDATE campaigns_campaignevent SET flow_id = $1 WHERE id = $2`, testdata.IVRFlow.ID, testdata.RemindersEvent1.ID)
-	db.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, testdata.Cathy.ID, testdata.George.ID, testdata.RemindersEvent1.ID)
+	rt.DB.MustExec(`UPDATE campaigns_campaignevent SET flow_id = $1 WHERE id = $2`, testdata.IVRFlow.ID, testdata.RemindersEvent1.ID)
+	rt.DB.MustExec(`INSERT INTO campaigns_eventfire(scheduled, contact_id, event_id) VALUES (NOW(), $1, $3), (NOW(), $2, $3);`, testdata.Cathy.ID, testdata.George.ID, testdata.RemindersEvent1.ID)
 	time.Sleep(10 * time.Millisecond)
 
 	// schedule our campaign to be started
-	err := fireCampaignEvents(ctx, db, rp, campaignsLock, "lock")
+	err := fireCampaignEvents(ctx, rt.DB, rt.RP, campaignsLock, "lock")
 	assert.NoError(t, err)
 
 	// then actually work on the event
@@ -82,7 +76,7 @@ func TestIVRCampaigns(t *testing.T) {
 	require.NoError(t, err)
 
 	// work on that task
-	err = typedTask.Perform(ctx, mr, models.OrgID(task.OrgID))
+	err = typedTask.Perform(ctx, rt, models.OrgID(task.OrgID))
 	assert.NoError(t, err)
 
 	// should now have a flow start created

--- a/core/tasks/campaigns/cron_test.go
+++ b/core/tasks/campaigns/cron_test.go
@@ -19,7 +19,7 @@ func TestCampaigns(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
 
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	rc := testsuite.RC()
 	defer rc.Close()
 
@@ -52,7 +52,7 @@ func TestCampaigns(t *testing.T) {
 func TestIVRCampaigns(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 	rc := testsuite.RC()
 	defer rc.Close()

--- a/core/tasks/campaigns/fire_campaign_event.go
+++ b/core/tasks/campaigns/fire_campaign_event.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows/triggers"
-	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/runner"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/marker"
 
 	"github.com/pkg/errors"
@@ -47,9 +47,9 @@ func (t *FireCampaignEventTask) Timeout() time.Duration {
 //   - creates the trigger for that event
 //   - runs the flow that is to be started through our engine
 //   - saves the flow run and session resulting from our run
-func (t *FireCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
-	db := mr.DB
-	rp := mr.RP
+func (t *FireCampaignEventTask) Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error {
+	db := rt.DB
+	rp := rt.RP
 	log := logrus.WithField("comp", "campaign_worker").WithField("event_id", t.EventID)
 
 	// grab all the fires for this event

--- a/core/tasks/campaigns/schedule_campaign_event.go
+++ b/core/tasks/campaigns/schedule_campaign_event.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/locker"
 
 	"github.com/pkg/errors"
@@ -33,9 +33,9 @@ func (t *ScheduleCampaignEventTask) Timeout() time.Duration {
 }
 
 // Perform creates the actual event fires to schedule the given campaign event
-func (t *ScheduleCampaignEventTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
-	db := mr.DB
-	rp := mr.RP
+func (t *ScheduleCampaignEventTask) Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error {
+	db := rt.DB
+	rp := rt.RP
 	lockKey := fmt.Sprintf(scheduleLockKey, t.CampaignEventID)
 
 	lock, err := locker.GrabLock(rp, lockKey, time.Hour, time.Minute*5)

--- a/core/tasks/campaigns/schedule_campaign_event_test.go
+++ b/core/tasks/campaigns/schedule_campaign_event_test.go
@@ -17,7 +17,7 @@ import (
 func TestScheduleCampaignEvent(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 
 	models.FlushCache()

--- a/core/tasks/contacts/import_contact_batch.go
+++ b/core/tasks/contacts/import_contact_batch.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/pkg/errors"
 )
 
@@ -28,13 +28,13 @@ func (t *ImportContactBatchTask) Timeout() time.Duration {
 }
 
 // Perform figures out the membership for a query based group then repopulates it
-func (t *ImportContactBatchTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
-	batch, err := models.LoadContactImportBatch(ctx, mr.DB, t.ContactImportBatchID)
+func (t *ImportContactBatchTask) Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error {
+	batch, err := models.LoadContactImportBatch(ctx, rt.DB, t.ContactImportBatchID)
 	if err != nil {
 		return errors.Wrapf(err, "unable to load contact import batch with id %d", t.ContactImportBatchID)
 	}
 
-	if err := batch.Import(ctx, mr.DB, orgID); err != nil {
+	if err := batch.Import(ctx, rt.DB, orgID); err != nil {
 		return errors.Wrapf(err, "unable to import contact import batch %d", t.ContactImportBatchID)
 	}
 

--- a/core/tasks/contacts/import_contact_batch_test.go
+++ b/core/tasks/contacts/import_contact_batch_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestImportContactBatch(t *testing.T) {
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 
 	importID := testdata.InsertContactImport(t, db, testdata.Org1)

--- a/core/tasks/contacts/import_contact_batch_test.go
+++ b/core/tasks/contacts/import_contact_batch_test.go
@@ -3,8 +3,6 @@ package contacts_test
 import (
 	"testing"
 
-	"github.com/nyaruka/mailroom"
-	"github.com/nyaruka/mailroom/config"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/tasks/contacts"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -15,9 +13,8 @@ import (
 
 func TestImportContactBatch(t *testing.T) {
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
-
-	mr := &mailroom.Mailroom{Config: config.Mailroom, DB: db, RP: testsuite.RP(), ElasticClient: nil}
+	rt := testsuite.Runtime()
+	db := rt.DB
 
 	importID := testdata.InsertContactImport(t, db, testdata.Org1)
 	batchID := testdata.InsertContactImportBatch(t, db, importID, []byte(`[
@@ -27,7 +24,7 @@ func TestImportContactBatch(t *testing.T) {
 
 	task := &contacts.ImportContactBatchTask{ContactImportBatchID: batchID}
 
-	err := task.Perform(ctx, mr, testdata.Org1.ID)
+	err := task.Perform(ctx, rt, testdata.Org1.ID)
 	require.NoError(t, err)
 
 	testsuite.AssertQueryCount(t, db, `SELECT count(*) FROM contacts_contact WHERE name = 'Norbert' AND language = 'eng'`, nil, 1)

--- a/core/tasks/expirations/cron.go
+++ b/core/tasks/expirations/cron.go
@@ -3,12 +3,14 @@ package expirations
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks/handler"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/cron"
 	"github.com/nyaruka/mailroom/utils/marker"
 
@@ -29,12 +31,12 @@ func init() {
 }
 
 // StartExpirationCron starts our cron job of expiring runs every minute
-func StartExpirationCron(mr *mailroom.Mailroom) error {
-	cron.StartCron(mr.Quit, mr.RP, expirationLock, time.Second*60,
+func StartExpirationCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
+	cron.StartCron(quit, rt.RP, expirationLock, time.Second*60,
 		func(lockName string, lockValue string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
-			return expireRuns(ctx, mr.DB, mr.RP, lockName, lockValue)
+			return expireRuns(ctx, rt.DB, rt.RP, lockName, lockValue)
 		},
 	)
 	return nil

--- a/core/tasks/groups/populate_dynamic_group.go
+++ b/core/tasks/groups/populate_dynamic_group.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/locker"
 
 	"github.com/pkg/errors"
@@ -35,13 +35,13 @@ func (t *PopulateDynamicGroupTask) Timeout() time.Duration {
 }
 
 // Perform figures out the membership for a query based group then repopulates it
-func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
+func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error {
 	lockKey := fmt.Sprintf(populateLockKey, t.GroupID)
-	lock, err := locker.GrabLock(mr.RP, lockKey, time.Hour, time.Minute*5)
+	lock, err := locker.GrabLock(rt.RP, lockKey, time.Hour, time.Minute*5)
 	if err != nil {
 		return errors.Wrapf(err, "error grabbing lock to repopulate dynamic group: %d", t.GroupID)
 	}
-	defer locker.ReleaseLock(mr.RP, lockKey, lock)
+	defer locker.ReleaseLock(rt.RP, lockKey, lock)
 
 	start := time.Now()
 	log := logrus.WithFields(logrus.Fields{
@@ -52,12 +52,12 @@ func (t *PopulateDynamicGroupTask) Perform(ctx context.Context, mr *mailroom.Mai
 
 	log.Info("starting population of dynamic group")
 
-	oa, err := models.GetOrgAssets(ctx, mr.DB, orgID)
+	oa, err := models.GetOrgAssets(ctx, rt.DB, orgID)
 	if err != nil {
 		return errors.Wrapf(err, "unable to load org when populating group: %d", t.GroupID)
 	}
 
-	count, err := models.PopulateDynamicGroup(ctx, mr.DB, mr.ElasticClient, oa, t.GroupID, t.Query)
+	count, err := models.PopulateDynamicGroup(ctx, rt.DB, rt.ES, oa, t.GroupID, t.Query)
 	if err != nil {
 		return errors.Wrapf(err, "error populating dynamic group: %d", t.GroupID)
 	}

--- a/core/tasks/groups/populate_dynamic_group_test.go
+++ b/core/tasks/groups/populate_dynamic_group_test.go
@@ -15,7 +15,7 @@ import (
 func TestPopulateTask(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := testsuite.DB()
 
 	mes := testsuite.NewMockElasticServer()

--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/queue"
 	"github.com/nyaruka/mailroom/core/runner"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/locker"
 	"github.com/nyaruka/null"
 	"github.com/pkg/errors"
@@ -85,8 +86,8 @@ func addHandleTask(rc redis.Conn, contactID models.ContactID, task *queue.Task, 
 	return addContactTask(rc, models.OrgID(task.OrgID), contactID)
 }
 
-func handleEvent(ctx context.Context, mr *mailroom.Mailroom, task *queue.Task) error {
-	return handleContactEvent(ctx, mr.DB, mr.RP, task)
+func handleEvent(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error {
+	return handleContactEvent(ctx, rt.DB, rt.RP, task)
 }
 
 // handleContactEvent is called when an event comes in for a contact.  to make sure we don't get into

--- a/core/tasks/interrupts/interrupt_sessions.go
+++ b/core/tasks/interrupts/interrupt_sessions.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
+	"github.com/nyaruka/mailroom/runtime"
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -63,8 +63,8 @@ func (t *InterruptSessionsTask) Timeout() time.Duration {
 	return time.Hour
 }
 
-func (t *InterruptSessionsTask) Perform(ctx context.Context, mr *mailroom.Mailroom, orgID models.OrgID) error {
-	db := mr.DB
+func (t *InterruptSessionsTask) Perform(ctx context.Context, rt *runtime.Runtime, orgID models.OrgID) error {
+	db := rt.DB
 
 	sessionIDs := make(map[models.SessionID]bool)
 	for _, sid := range t.SessionIDs {

--- a/core/tasks/interrupts/interrupt_sessions_test.go
+++ b/core/tasks/interrupts/interrupt_sessions_test.go
@@ -15,7 +15,7 @@ import (
 func TestInterrupts(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 
 	insertConnection := func(orgID models.OrgID, channelID models.ChannelID, contactID models.ContactID, urnID models.URNID) models.ConnectionID {

--- a/core/tasks/interrupts/interrupt_sessions_test.go
+++ b/core/tasks/interrupts/interrupt_sessions_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/uuids"
-	"github.com/nyaruka/mailroom"
-	"github.com/nyaruka/mailroom/config"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -17,9 +15,8 @@ import (
 func TestInterrupts(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
-
-	mr := &mailroom.Mailroom{Config: config.Mailroom, DB: db, RP: testsuite.RP(), ElasticClient: nil}
+	rt := testsuite.Runtime()
+	db := rt.DB
 
 	insertConnection := func(orgID models.OrgID, channelID models.ChannelID, contactID models.ContactID, urnID models.URNID) models.ConnectionID {
 		var connectionID models.ConnectionID
@@ -106,7 +103,7 @@ func TestInterrupts(t *testing.T) {
 		}
 
 		// execute it
-		err := task.Perform(ctx, mr, testdata.Org1.ID)
+		err := task.Perform(ctx, rt, testdata.Org1.ID)
 		assert.NoError(t, err)
 
 		// check session statuses are as expected

--- a/core/tasks/ivr/worker.go
+++ b/core/tasks/ivr/worker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/mailroom/core/ivr"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -20,7 +21,7 @@ func init() {
 	mailroom.AddTaskFunction(queue.StartIVRFlowBatch, handleFlowStartTask)
 }
 
-func handleFlowStartTask(ctx context.Context, mr *mailroom.Mailroom, task *queue.Task) error {
+func handleFlowStartTask(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error {
 	// decode our task body
 	if task.Type != queue.StartIVRFlowBatch {
 		return errors.Errorf("unknown event type passed to ivr worker: %s", task.Type)
@@ -31,7 +32,7 @@ func handleFlowStartTask(ctx context.Context, mr *mailroom.Mailroom, task *queue
 		return errors.Wrapf(err, "error unmarshalling flow start batch: %s", string(task.Task))
 	}
 
-	return HandleFlowStartBatch(ctx, mr.Config, mr.DB, mr.RP, batch)
+	return HandleFlowStartBatch(ctx, rt.Config, rt.DB, rt.RP, batch)
 }
 
 // HandleFlowStartBatch starts a batch of contacts in an IVR flow

--- a/core/tasks/starts/worker_test.go
+++ b/core/tasks/starts/worker_test.go
@@ -21,7 +21,7 @@ import (
 func TestStarts(t *testing.T) {
 	testsuite.Reset()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	rp := rt.RP
 	db := rt.DB
 	rc := testsuite.RC()

--- a/core/tasks/stats/cron.go
+++ b/core/tasks/stats/cron.go
@@ -2,11 +2,13 @@ package stats
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/nyaruka/librato"
 	"github.com/nyaruka/mailroom"
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/utils/cron"
 	"github.com/sirupsen/logrus"
 
@@ -23,12 +25,12 @@ func init() {
 }
 
 // StartStatsCron starts our cron job of posting stats every minute
-func StartStatsCron(mr *mailroom.Mailroom) error {
-	cron.StartCron(mr.Quit, mr.RP, expirationLock, time.Second*60,
+func StartStatsCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
+	cron.StartCron(quit, rt.RP, expirationLock, time.Second*60,
 		func(lockName string, lockValue string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
-			return dumpStats(ctx, mr.DB, mr.RP, lockName, lockValue)
+			return dumpStats(ctx, rt.DB, rt.RP, lockName, lockValue)
 		},
 	)
 	return nil

--- a/mailroom.go
+++ b/mailroom.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/gocommon/storage"
 	"github.com/nyaruka/mailroom/config"
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 
 	"github.com/gomodule/redigo/redis"
@@ -22,7 +23,7 @@ import (
 )
 
 // InitFunction is a function that will be called when mailroom starts
-type InitFunction func(mr *Mailroom) error
+type InitFunction func(runtime *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error
 
 var initFunctions = make([]InitFunction, 0)
 
@@ -32,7 +33,7 @@ func AddInitFunction(initFunc InitFunction) {
 }
 
 // TaskFunction is the function that will be called for a type of task
-type TaskFunction func(ctx context.Context, mr *Mailroom, task *queue.Task) error
+type TaskFunction func(ctx context.Context, rt *runtime.Runtime, task *queue.Task) error
 
 var taskFunctions = make(map[string]TaskFunction)
 
@@ -43,16 +44,12 @@ func AddTaskFunction(taskType string, taskFunc TaskFunction) {
 
 // Mailroom is a service for handling RapidPro events
 type Mailroom struct {
-	Config        *config.Config
-	DB            *sqlx.DB
-	RP            *redis.Pool
-	ElasticClient *elastic.Client
-	Storage       storage.Storage
+	ctx    context.Context
+	cancel context.CancelFunc
 
-	Quit      chan bool
-	CTX       context.Context
-	Cancel    context.CancelFunc
-	WaitGroup *sync.WaitGroup
+	rt   *runtime.Runtime
+	wg   *sync.WaitGroup
+	quit chan bool
 
 	batchForeman   *Foreman
 	handlerForeman *Foreman
@@ -63,48 +60,50 @@ type Mailroom struct {
 // NewMailroom creates and returns a new mailroom instance
 func NewMailroom(config *config.Config) *Mailroom {
 	mr := &Mailroom{
-		Config:    config,
-		Quit:      make(chan bool),
-		WaitGroup: &sync.WaitGroup{},
+		rt:   &runtime.Runtime{Config: config},
+		quit: make(chan bool),
+		wg:   &sync.WaitGroup{},
 	}
-	mr.CTX, mr.Cancel = context.WithCancel(context.Background())
-	mr.batchForeman = NewForeman(mr, queue.BatchQueue, config.BatchWorkers)
-	mr.handlerForeman = NewForeman(mr, queue.HandlerQueue, config.HandlerWorkers)
+	mr.ctx, mr.cancel = context.WithCancel(context.Background())
+	mr.batchForeman = NewForeman(mr.rt, mr.wg, queue.BatchQueue, config.BatchWorkers)
+	mr.handlerForeman = NewForeman(mr.rt, mr.wg, queue.HandlerQueue, config.HandlerWorkers)
 
 	return mr
 }
 
 // Start starts the mailroom service
 func (mr *Mailroom) Start() error {
+	c := mr.rt.Config
+
 	log := logrus.WithFields(logrus.Fields{
 		"state": "starting",
 	})
 
 	// parse and test our db config
-	dbURL, err := url.Parse(mr.Config.DB)
+	dbURL, err := url.Parse(c.DB)
 	if err != nil {
-		return fmt.Errorf("unable to parse DB URL '%s': %s", mr.Config.DB, err)
+		return fmt.Errorf("unable to parse DB URL '%s': %s", c.DB, err)
 	}
 
 	if dbURL.Scheme != "postgres" {
-		return fmt.Errorf("invalid DB URL: '%s', only postgres is supported", mr.Config.DB)
+		return fmt.Errorf("invalid DB URL: '%s', only postgres is supported", c.DB)
 	}
 
 	// build our db
-	db, err := sqlx.Open("postgres", mr.Config.DB)
+	db, err := sqlx.Open("postgres", c.DB)
 	if err != nil {
-		return fmt.Errorf("unable to open DB with config: '%s': %s", mr.Config.DB, err)
+		return fmt.Errorf("unable to open DB with config: '%s': %s", c.DB, err)
 	}
 
 	// configure our pool
-	mr.DB = db
-	mr.DB.SetMaxIdleConns(8)
-	mr.DB.SetMaxOpenConns(mr.Config.DBPoolSize)
-	mr.DB.SetConnMaxLifetime(time.Minute * 30)
+	db.SetMaxIdleConns(8)
+	db.SetMaxOpenConns(c.DBPoolSize)
+	db.SetConnMaxLifetime(time.Minute * 30)
+	mr.rt.DB = db
 
 	// try connecting
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	err = mr.DB.PingContext(ctx)
+	err = db.PingContext(ctx)
 	cancel()
 	if err != nil {
 		log.Error("db not reachable")
@@ -113,9 +112,9 @@ func (mr *Mailroom) Start() error {
 	}
 
 	// parse and test our redis config
-	redisURL, err := url.Parse(mr.Config.Redis)
+	redisURL, err := url.Parse(mr.rt.Config.Redis)
 	if err != nil {
-		return fmt.Errorf("unable to parse Redis URL '%s': %s", mr.Config.Redis, err)
+		return fmt.Errorf("unable to parse Redis URL '%s': %s", c.Redis, err)
 	}
 
 	// create our pool
@@ -146,7 +145,7 @@ func (mr *Mailroom) Start() error {
 			return conn, err
 		},
 	}
-	mr.RP = redisPool
+	mr.rt.RP = redisPool
 
 	// test our redis connection
 	conn := redisPool.Get()
@@ -159,33 +158,33 @@ func (mr *Mailroom) Start() error {
 	}
 
 	// create our storage (S3 or file system)
-	if mr.Config.AWSAccessKeyID != "" {
+	if mr.rt.Config.AWSAccessKeyID != "" {
 		s3Client, err := storage.NewS3Client(&storage.S3Options{
-			AWSAccessKeyID:     mr.Config.AWSAccessKeyID,
-			AWSSecretAccessKey: mr.Config.AWSSecretAccessKey,
-			Endpoint:           mr.Config.S3Endpoint,
-			Region:             mr.Config.S3Region,
-			DisableSSL:         mr.Config.S3DisableSSL,
-			ForcePathStyle:     mr.Config.S3ForcePathStyle,
+			AWSAccessKeyID:     c.AWSAccessKeyID,
+			AWSSecretAccessKey: c.AWSSecretAccessKey,
+			Endpoint:           c.S3Endpoint,
+			Region:             c.S3Region,
+			DisableSSL:         c.S3DisableSSL,
+			ForcePathStyle:     c.S3ForcePathStyle,
 		})
 		if err != nil {
 			return err
 		}
-		mr.Storage = storage.NewS3(s3Client, mr.Config.S3MediaBucket)
+		mr.rt.Storage = storage.NewS3(s3Client, c.S3MediaBucket)
 	} else {
-		mr.Storage = storage.NewFS("_storage")
+		mr.rt.Storage = storage.NewFS("_storage")
 	}
 
 	// test our storage
-	err = mr.Storage.Test()
+	err = mr.rt.Storage.Test()
 	if err != nil {
-		log.WithError(err).Error(mr.Storage.Name() + " storage not available")
+		log.WithError(err).Error(mr.rt.Storage.Name() + " storage not available")
 	} else {
-		log.Info(mr.Storage.Name() + " storage ok")
+		log.Info(mr.rt.Storage.Name() + " storage ok")
 	}
 
 	// initialize our elastic client
-	mr.ElasticClient, err = newElasticClient(mr.Config.Elastic)
+	mr.rt.ES, err = newElasticClient(c.Elastic)
 	if err != nil {
 		log.WithError(err).Error("unable to connect to elastic, check configuration")
 	} else {
@@ -193,18 +192,18 @@ func (mr *Mailroom) Start() error {
 	}
 
 	// warn if we won't be doing FCM syncing
-	if config.Mailroom.FCMKey == "" {
+	if c.FCMKey == "" {
 		logrus.Error("fcm not configured, no syncing of android channels")
 	}
 
 	for _, initFunc := range initFunctions {
-		initFunc(mr)
+		initFunc(mr.rt, mr.wg, mr.quit)
 	}
 
 	// if we have a librato token, configure it
-	if mr.Config.LibratoToken != "" {
+	if c.LibratoToken != "" {
 		host, _ := os.Hostname()
-		librato.Configure(mr.Config.LibratoUsername, mr.Config.LibratoToken, host, time.Second, mr.WaitGroup)
+		librato.Configure(c.LibratoUsername, c.LibratoToken, host, time.Second, mr.wg)
 		librato.Start()
 	}
 
@@ -213,7 +212,7 @@ func (mr *Mailroom) Start() error {
 	mr.handlerForeman.Start()
 
 	// start our web server
-	mr.webserver = web.NewServer(mr.CTX, mr.Config, mr.DB, mr.RP, mr.Storage, mr.ElasticClient, mr.WaitGroup)
+	mr.webserver = web.NewServer(mr.ctx, c, mr.rt.DB, mr.rt.RP, mr.rt.Storage, mr.rt.ES, mr.wg)
 	mr.webserver.Start()
 
 	logrus.Info("mailroom started")
@@ -227,14 +226,14 @@ func (mr *Mailroom) Stop() error {
 	mr.batchForeman.Stop()
 	mr.handlerForeman.Stop()
 	librato.Stop()
-	close(mr.Quit)
-	mr.Cancel()
+	close(mr.quit)
+	mr.cancel()
 
 	// stop our web server
 	mr.webserver.Stop()
 
-	mr.WaitGroup.Wait()
-	mr.ElasticClient.Stop()
+	mr.wg.Wait()
+	mr.rt.ES.Stop()
 	logrus.Info("mailroom stopped")
 	return nil
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,0 +1,19 @@
+package runtime
+
+import (
+	"github.com/gomodule/redigo/redis"
+	"github.com/jmoiron/sqlx"
+	"github.com/nyaruka/gocommon/storage"
+	"github.com/nyaruka/mailroom/config"
+	"github.com/olivere/elastic/v7"
+)
+
+// Runtime represents the set of services required to run many Mailroom functions. Used as a wrapper for
+// those services to simplify call signatures but not create a direct dependency to Mailroom or Server
+type Runtime struct {
+	DB      *sqlx.DB
+	RP      *redis.Pool
+	ES      *elastic.Client
+	Storage storage.Storage
+	Config  *config.Config
+}

--- a/services/tickets/mailgun/web.go
+++ b/services/tickets/mailgun/web.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets"
 	"github.com/nyaruka/mailroom/web"
 
@@ -60,13 +61,13 @@ type receiveResponse struct {
 
 var addressRegex = regexp.MustCompile(`^ticket\+([0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12})@.*$`)
 
-func handleReceive(ctx context.Context, s *web.Server, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+func handleReceive(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
 	request := &receiveRequest{}
 	if err := web.DecodeAndValidateForm(request, r); err != nil {
 		return errors.Wrapf(err, "error decoding form"), http.StatusBadRequest, nil
 	}
 
-	if !request.verify(s.Config.MailgunSigningKey) {
+	if !request.verify(rt.Config.MailgunSigningKey) {
 		return errors.New("request signature validation failed"), http.StatusForbidden, nil
 	}
 
@@ -87,7 +88,7 @@ func handleReceive(ctx context.Context, s *web.Server, r *http.Request, l *model
 	}
 
 	// look up the ticket and ticketer
-	ticket, ticketer, svc, err := tickets.FromTicketUUID(s.CTX, s.DB, flows.TicketUUID(match[0][1]), typeMailgun)
+	ticket, ticketer, svc, err := tickets.FromTicketUUID(ctx, rt.DB, flows.TicketUUID(match[0][1]), typeMailgun)
 	if err != nil {
 		return err, http.StatusBadRequest, nil
 	}
@@ -105,8 +106,8 @@ func handleReceive(ctx context.Context, s *web.Server, r *http.Request, l *model
 
 	// check if reply is actually a command
 	if strings.ToLower(strings.TrimSpace(request.StrippedText)) == "close" {
-		org, _ := models.GetOrgAssets(ctx, s.DB, ticket.OrgID())
-		err = models.CloseTickets(ctx, s.DB, org, []*models.Ticket{ticket}, true, l)
+		org, _ := models.GetOrgAssets(ctx, rt.DB, ticket.OrgID())
+		err = models.CloseTickets(ctx, rt.DB, org, []*models.Ticket{ticket}, true, l)
 		if err != nil {
 			return errors.Wrapf(err, "error closing ticket: %s", ticket.UUID()), http.StatusInternalServerError, nil
 		}
@@ -118,12 +119,12 @@ func handleReceive(ctx context.Context, s *web.Server, r *http.Request, l *model
 	config := map[string]string{
 		ticketConfigLastMessageID: request.MessageID,
 	}
-	err = models.UpdateAndKeepOpenTicket(ctx, s.DB, ticket, config)
+	err = models.UpdateAndKeepOpenTicket(ctx, rt.DB, ticket, config)
 	if err != nil {
 		return errors.Wrapf(err, "error updating ticket: %s", ticket.UUID()), http.StatusInternalServerError, nil
 	}
 
-	msg, err := tickets.SendReply(ctx, s.DB, s.RP, s.Storage, ticket, request.StrippedText, files)
+	msg, err := tickets.SendReply(ctx, rt, ticket, request.StrippedText, files)
 	if err != nil {
 		return err, http.StatusInternalServerError, nil
 	}

--- a/services/tickets/rocketchat/web.go
+++ b/services/tickets/rocketchat/web.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/go-chi/chi"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets"
 	"github.com/nyaruka/mailroom/web"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 func init() {
@@ -35,11 +37,11 @@ type agentMessageData struct {
 	} `json:"attachments"`
 }
 
-func handleEventCallback(ctx context.Context, s *web.Server, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+func handleEventCallback(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
 	ticketerUUID := assets.TicketerUUID(chi.URLParam(r, "ticketer"))
 
 	// look up ticketer
-	ticketer, _, err := tickets.FromTicketerUUID(ctx, s.DB, ticketerUUID, typeRocketChat)
+	ticketer, _, err := tickets.FromTicketerUUID(ctx, rt.DB, ticketerUUID, typeRocketChat)
 	if err != nil {
 		return errors.Errorf("no such ticketer %s", ticketerUUID), http.StatusNotFound, nil
 	}
@@ -56,7 +58,7 @@ func handleEventCallback(ctx context.Context, s *web.Server, r *http.Request, l 
 	}
 
 	// look up ticket
-	ticket, _, _, err := tickets.FromTicketUUID(ctx, s.DB, flows.TicketUUID(request.TicketID), typeRocketChat)
+	ticket, _, _, err := tickets.FromTicketUUID(ctx, rt.DB, flows.TicketUUID(request.TicketID), typeRocketChat)
 	if err != nil {
 		return errors.Errorf("no such ticket %s", request.TicketID), http.StatusNotFound, nil
 	}
@@ -88,10 +90,10 @@ func handleEventCallback(ctx context.Context, s *web.Server, r *http.Request, l 
 			attachments = append(attachments, attachment.URL)
 		}
 
-		_, err = tickets.SendReply(ctx, s.DB, s.RP, s.Storage, ticket, data.Text, files)
+		_, err = tickets.SendReply(ctx, rt, ticket, data.Text, files)
 
 	case "close-room":
-		err = models.CloseTickets(ctx, s.DB, nil, []*models.Ticket{ticket}, false, l)
+		err = models.CloseTickets(ctx, rt.DB, nil, []*models.Ticket{ticket}, false, l)
 
 	default:
 		err = errors.New("invalid event type")

--- a/services/tickets/utils.go
+++ b/services/tickets/utils.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/nyaruka/gocommon/httpx"
-	"github.com/nyaruka/gocommon/storage"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
@@ -19,9 +19,8 @@ import (
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/msgio"
+	"github.com/nyaruka/mailroom/runtime"
 
-	"github.com/gomodule/redigo/redis"
-	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 )
 
@@ -80,9 +79,9 @@ func FromTicketerUUID(ctx context.Context, db *sqlx.DB, uuid assets.TicketerUUID
 }
 
 // SendReply sends a message reply from the ticket system user to the contact
-func SendReply(ctx context.Context, db *sqlx.DB, rp *redis.Pool, store storage.Storage, ticket *models.Ticket, text string, files []*File) (*models.Msg, error) {
+func SendReply(ctx context.Context, rt *runtime.Runtime, ticket *models.Ticket, text string, files []*File) (*models.Msg, error) {
 	// look up our assets
-	oa, err := models.GetOrgAssets(ctx, db, ticket.OrgID())
+	oa, err := models.GetOrgAssets(ctx, rt.DB, ticket.OrgID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "error looking up org #%d", ticket.OrgID())
 	}
@@ -92,7 +91,7 @@ func SendReply(ctx context.Context, db *sqlx.DB, rp *redis.Pool, store storage.S
 	for i, file := range files {
 		filename := string(uuids.New()) + filepath.Ext(file.URL)
 
-		attachments[i], err = oa.Org().StoreAttachment(store, filename, file.ContentType, file.Body)
+		attachments[i], err = oa.Org().StoreAttachment(rt.Storage, filename, file.ContentType, file.Body)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error storing attachment %s for ticket reply", file.URL)
 		}
@@ -105,12 +104,12 @@ func SendReply(ctx context.Context, db *sqlx.DB, rp *redis.Pool, store storage.S
 	// we'll use a broadcast to send this message
 	bcast := models.NewBroadcast(oa.OrgID(), models.NilBroadcastID, translations, models.TemplateStateEvaluated, envs.Language("base"), nil, nil, nil)
 	batch := bcast.CreateBatch([]models.ContactID{ticket.ContactID()})
-	msgs, err := models.CreateBroadcastMessages(ctx, db, rp, oa, batch)
+	msgs, err := models.CreateBroadcastMessages(ctx, rt.DB, rt.RP, oa, batch)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating message batch")
 	}
 
-	msgio.SendMessages(ctx, db, rp, nil, msgs)
+	msgio.SendMessages(ctx, rt.DB, rt.RP, nil, msgs)
 	return msgs[0], nil
 }
 

--- a/services/tickets/utils_test.go
+++ b/services/tickets/utils_test.go
@@ -120,7 +120,7 @@ func TestFromTicketerUUID(t *testing.T) {
 func TestSendReply(t *testing.T) {
 	testsuite.ResetDB()
 	ctx := testsuite.CTX()
-	rt := testsuite.Runtime()
+	rt := testsuite.RT()
 	db := rt.DB
 	defer testsuite.ResetStorage()
 

--- a/services/tickets/utils_test.go
+++ b/services/tickets/utils_test.go
@@ -120,8 +120,8 @@ func TestFromTicketerUUID(t *testing.T) {
 func TestSendReply(t *testing.T) {
 	testsuite.ResetDB()
 	ctx := testsuite.CTX()
-	db := testsuite.DB()
-	rp := testsuite.RP()
+	rt := testsuite.Runtime()
+	db := rt.DB
 	defer testsuite.ResetStorage()
 
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
@@ -140,7 +140,7 @@ func TestSendReply(t *testing.T) {
 	ticket, err := models.LookupTicketByUUID(ctx, db, ticketUUID)
 	require.NoError(t, err)
 
-	msg, err := tickets.SendReply(ctx, db, rp, testsuite.Storage(), ticket, "I'll get back to you", []*tickets.File{image})
+	msg, err := tickets.SendReply(ctx, rt, ticket, "I'll get back to you", []*tickets.File{image})
 	require.NoError(t, err)
 
 	assert.Equal(t, "I'll get back to you", msg.Text())
@@ -149,6 +149,6 @@ func TestSendReply(t *testing.T) {
 	assert.FileExists(t, "_test_storage/media/1/1ae9/6956/1ae96956-4b34-433e-8d1a-f05fe6923d6d.jpg")
 
 	// try with file that can't be read (i.e. same file again which is already closed)
-	_, err = tickets.SendReply(ctx, db, rp, testsuite.Storage(), ticket, "I'll get back to you", []*tickets.File{image})
+	_, err = tickets.SendReply(ctx, rt, ticket, "I'll get back to you", []*tickets.File{image})
 	assert.EqualError(t, err, "error storing attachment http://coolfiles.com/a.jpg for ticket reply: unable to read attachment content: read ../../core/models/testdata/test.jpg: file already closed")
 }

--- a/services/tickets/zendesk/web.go
+++ b/services/tickets/zendesk/web.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/services/tickets"
 	"github.com/nyaruka/mailroom/web"
 
@@ -48,7 +49,7 @@ type channelbackResponse struct {
 	AllowChannelback bool   `json:"allow_channelback"`
 }
 
-func handleChannelback(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleChannelback(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &channelbackRequest{}
 	if err := web.DecodeAndValidateForm(request, r); err != nil {
 		return errors.Wrapf(err, "error decoding form"), http.StatusBadRequest, nil
@@ -61,7 +62,7 @@ func handleChannelback(ctx context.Context, s *web.Server, r *http.Request) (int
 	}
 
 	// lookup the ticket and ticketer
-	ticket, ticketer, _, err := tickets.FromTicketUUID(ctx, s.DB, flows.TicketUUID(request.ThreadID), typeZendesk)
+	ticket, ticketer, _, err := tickets.FromTicketUUID(ctx, rt.DB, flows.TicketUUID(request.ThreadID), typeZendesk)
 	if err != nil {
 		return err, http.StatusBadRequest, nil
 	}
@@ -71,7 +72,7 @@ func handleChannelback(ctx context.Context, s *web.Server, r *http.Request) (int
 		return errors.New("ticketer secret mismatch"), http.StatusUnauthorized, nil
 	}
 
-	err = models.UpdateAndKeepOpenTicket(ctx, s.DB, ticket, nil)
+	err = models.UpdateAndKeepOpenTicket(ctx, rt.DB, ticket, nil)
 	if err != nil {
 		return errors.Wrapf(err, "error updating ticket: %s", ticket.UUID()), http.StatusBadRequest, nil
 	}
@@ -85,7 +86,7 @@ func handleChannelback(ctx context.Context, s *web.Server, r *http.Request) (int
 		}
 	}
 
-	msg, err := tickets.SendReply(ctx, s.DB, s.RP, s.Storage, ticket, request.Message, files)
+	msg, err := tickets.SendReply(ctx, rt, ticket, request.Message, files)
 	if err != nil {
 		return err, http.StatusBadRequest, nil
 	}
@@ -123,14 +124,14 @@ type eventCallbackRequest struct {
 	Events []*channelEvent `json:"events" validate:"required"`
 }
 
-func handleEventCallback(ctx context.Context, s *web.Server, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+func handleEventCallback(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
 	request := &eventCallbackRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return err, http.StatusBadRequest, nil
 	}
 
 	for _, e := range request.Events {
-		if err := processChannelEvent(ctx, s.DB, e, l); err != nil {
+		if err := processChannelEvent(ctx, rt.DB, e, l); err != nil {
 			return err, http.StatusBadRequest, nil
 		}
 	}
@@ -244,11 +245,11 @@ type targetRequest struct {
 	Status string `json:"status"`
 }
 
-func handleTicketerTarget(ctx context.Context, s *web.Server, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+func handleTicketerTarget(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
 	ticketerUUID := assets.TicketerUUID(chi.URLParam(r, "ticketer"))
 
 	// look up our ticketer
-	ticketer, _, err := tickets.FromTicketerUUID(ctx, s.DB, ticketerUUID, typeZendesk)
+	ticketer, _, err := tickets.FromTicketerUUID(ctx, rt.DB, ticketerUUID, typeZendesk)
 	if err != nil || ticketer == nil {
 		return errors.Errorf("no such ticketer %s", ticketerUUID), http.StatusNotFound, nil
 	}
@@ -266,7 +267,7 @@ func handleTicketerTarget(ctx context.Context, s *web.Server, r *http.Request, l
 	}
 
 	// lookup ticket
-	ticket, err := models.LookupTicketByExternalID(ctx, s.DB, ticketer.ID(), fmt.Sprintf("%d", request.ID))
+	ticket, err := models.LookupTicketByExternalID(ctx, rt.DB, ticketer.ID(), fmt.Sprintf("%d", request.ID))
 	if err != nil || ticket == nil {
 		// we don't return an error here, because ticket might just belong to a different ticketer
 		return map[string]string{"status": "ignored"}, http.StatusOK, nil
@@ -275,9 +276,9 @@ func handleTicketerTarget(ctx context.Context, s *web.Server, r *http.Request, l
 	if request.Event == "status_changed" {
 		switch strings.ToLower(request.Status) {
 		case statusSolved, statusClosed:
-			err = models.CloseTickets(ctx, s.DB, nil, []*models.Ticket{ticket}, false, l)
+			err = models.CloseTickets(ctx, rt.DB, nil, []*models.Ticket{ticket}, false, l)
 		case statusOpen:
-			err = models.ReopenTickets(ctx, s.DB, nil, []*models.Ticket{ticket}, false, l)
+			err = models.ReopenTickets(ctx, rt.DB, nil, []*models.Ticket{ticket}, false, l)
 		}
 
 		if err != nil {

--- a/testsuite/testdata/tickets.go
+++ b/testsuite/testdata/tickets.go
@@ -3,11 +3,11 @@ package testdata
 import (
 	"testing"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -170,7 +170,7 @@ func AssertCourierQueues(t *testing.T, expected map[string][]int, errMsg ...inte
 	assert.Equal(t, expected, actual, errMsg...)
 }
 
-func Runtime() *runtime.Runtime {
+func RT() *runtime.Runtime {
 	return &runtime.Runtime{
 		RP:      RP(),
 		DB:      DB(),

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/storage"
+	"github.com/nyaruka/mailroom/config"
+	"github.com/nyaruka/mailroom/runtime"
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/jmoiron/sqlx"
@@ -166,4 +168,14 @@ func AssertCourierQueues(t *testing.T, expected map[string][]int, errMsg ...inte
 	}
 
 	assert.Equal(t, expected, actual, errMsg...)
+}
+
+func Runtime() *runtime.Runtime {
+	return &runtime.Runtime{
+		RP:      RP(),
+		DB:      DB(),
+		ES:      nil,
+		Storage: Storage(),
+		Config:  config.NewMailroomConfig(),
+	}
 }

--- a/web/docs/docs.go
+++ b/web/docs/docs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 )
 
@@ -13,7 +14,7 @@ func init() {
 	docServer = http.StripPrefix("/mr/docs", http.FileServer(http.Dir("docs")))
 
 	// redirect non slashed docs to slashed version so relative URLs work
-	web.RegisterRoute(http.MethodGet, "/mr/docs", func(ctx context.Context, s *web.Server, r *http.Request, rawW http.ResponseWriter) error {
+	web.RegisterRoute(http.MethodGet, "/mr/docs", func(ctx context.Context, rt *runtime.Runtime, r *http.Request, rawW http.ResponseWriter) error {
 		http.Redirect(rawW, r, "/mr/docs/", http.StatusMovedPermanently)
 		return nil
 	})
@@ -22,7 +23,7 @@ func init() {
 	web.RegisterRoute(http.MethodGet, "/mr/docs/*", handleDocs)
 }
 
-func handleDocs(ctx context.Context, s *web.Server, r *http.Request, rawW http.ResponseWriter) error {
+func handleDocs(ctx context.Context, rt *runtime.Runtime, r *http.Request, rawW http.ResponseWriter) error {
 	docServer.ServeHTTP(rawW, r)
 	return nil
 }

--- a/web/expression/expression.go
+++ b/web/expression/expression.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nyaruka/goflow/flows/definition/legacy/expressions"
 	"github.com/nyaruka/goflow/utils"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 
 	"github.com/pkg/errors"
@@ -29,7 +30,7 @@ type migrateResponse struct {
 	Migrated string `json:"migrated"`
 }
 
-func handleMigrate(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleMigrate(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &migrateRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation"), http.StatusBadRequest, nil

--- a/web/flow/flow.go
+++ b/web/flow/flow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/goflow"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 
 	"github.com/Masterminds/semver"
@@ -36,7 +37,7 @@ type migrateRequest struct {
 	ToVersion *semver.Version `json:"to_version"`
 }
 
-func handleMigrate(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleMigrate(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &migrateRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation"), http.StatusBadRequest, nil
@@ -71,7 +72,7 @@ type inspectRequest struct {
 	OrgID models.OrgID    `json:"org_id"`
 }
 
-func handleInspect(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleInspect(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &inspectRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation"), http.StatusBadRequest, nil
@@ -85,7 +86,7 @@ func handleInspect(ctx context.Context, s *web.Server, r *http.Request) (interfa
 	var sa flows.SessionAssets
 	// if we have an org ID, create session assets to look for missing dependencies
 	if request.OrgID != models.NilOrgID {
-		oa, err := models.GetOrgAssetsWithRefresh(ctx, s.DB, request.OrgID, models.RefreshFields|models.RefreshGroups|models.RefreshFlows)
+		oa, err := models.GetOrgAssetsWithRefresh(ctx, rt.DB, request.OrgID, models.RefreshFields|models.RefreshGroups|models.RefreshFlows)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -110,7 +111,7 @@ type cloneRequest struct {
 	Flow              json.RawMessage           `json:"flow" validate:"required"`
 }
 
-func handleClone(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleClone(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &cloneRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation"), http.StatusBadRequest, nil
@@ -143,7 +144,7 @@ type changeLanguageRequest struct {
 	Flow     json.RawMessage `json:"flow"     validate:"required"`
 }
 
-func handleChangeLanguage(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleChangeLanguage(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	request := &changeLanguageRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation"), http.StatusBadRequest, nil

--- a/web/ivr/ivr.go
+++ b/web/ivr/ivr.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nyaruka/mailroom/core/ivr"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks/handler"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 
 	"github.com/go-chi/chi"
@@ -29,10 +30,10 @@ func init() {
 	web.RegisterRoute(http.MethodPost, "/mr/ivr/c/{uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/incoming", newIVRHandler(handleIncomingCall))
 }
 
-type ivrHandlerFn func(ctx context.Context, s *web.Server, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error)
+type ivrHandlerFn func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error)
 
 func newIVRHandler(handler ivrHandlerFn) web.Handler {
-	return func(ctx context.Context, s *web.Server, r *http.Request, w http.ResponseWriter) error {
+	return func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error {
 		recorder := httpx.NewRecorder(r, w)
 
 		// immediately save our request body so we have a complete channel log
@@ -42,7 +43,7 @@ func newIVRHandler(handler ivrHandlerFn) web.Handler {
 		}
 		ww := recorder.ResponseWriter
 
-		channel, connection, rerr := handler(ctx, s, r, ww)
+		channel, connection, rerr := handler(ctx, rt, r, ww)
 
 		if channel != nil {
 			trace, err := recorder.End()
@@ -58,7 +59,7 @@ func newIVRHandler(handler ivrHandlerFn) web.Handler {
 			}
 
 			log := models.NewChannelLog(trace, isError, desc, channel, connection)
-			err = models.InsertChannelLogs(ctx, s.DB, []*models.ChannelLog{log})
+			err = models.InsertChannelLogs(ctx, rt.DB, []*models.ChannelLog{log})
 			if err != nil {
 				logrus.WithError(err).WithField("http_request", r).Error("error writing ivr channel log")
 			}
@@ -68,17 +69,17 @@ func newIVRHandler(handler ivrHandlerFn) web.Handler {
 	}
 }
 
-func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
+func handleIncomingCall(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
 	channelUUID := assets.ChannelUUID(chi.URLParam(r, "uuid"))
 
 	// load the org id for this UUID (we could load the entire channel here but we want to take the same paths through everything else)
-	orgID, err := models.OrgIDForChannelUUID(ctx, s.DB, channelUUID)
+	orgID, err := models.OrgIDForChannelUUID(ctx, rt.DB, channelUUID)
 	if err != nil {
 		return nil, nil, writeClientError(w, err)
 	}
 
 	// load our org assets
-	oa, err := models.GetOrgAssets(ctx, s.DB, orgID)
+	oa, err := models.GetOrgAssets(ctx, rt.DB, orgID)
 	if err != nil {
 		return nil, nil, writeClientError(w, errors.Wrapf(err, "error loading org assets"))
 	}
@@ -108,12 +109,12 @@ func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w h
 	}
 
 	// get the contact for this URN
-	contact, _, _, err := models.GetOrCreateContact(ctx, s.DB, oa, []urns.URN{urn}, channel.ID())
+	contact, _, _, err := models.GetOrCreateContact(ctx, rt.DB, oa, []urns.URN{urn}, channel.ID())
 	if err != nil {
 		return channel, nil, client.WriteErrorResponse(w, errors.Wrapf(err, "unable to get contact by urn"))
 	}
 
-	urn, err = models.URNForURN(ctx, s.DB, oa, urn)
+	urn, err = models.URNForURN(ctx, rt.DB, oa, urn)
 	if err != nil {
 		return channel, nil, client.WriteErrorResponse(w, errors.Wrapf(err, "unable to load urn"))
 	}
@@ -134,7 +135,7 @@ func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w h
 
 	// create our connection
 	conn, err := models.InsertIVRConnection(
-		ctx, s.DB, oa.OrgID(), channel.ID(), models.NilStartID, contact.ID(), urnID,
+		ctx, rt.DB, oa.OrgID(), channel.ID(), models.NilStartID, contact.ID(), urnID,
 		models.ConnectionDirectionIn, models.ConnectionStatusInProgress, externalID,
 	)
 	if err != nil {
@@ -142,7 +143,7 @@ func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w h
 	}
 
 	// try to handle this event
-	session, err := handler.HandleChannelEvent(ctx, s.DB, s.RP, models.MOCallEventType, event, conn)
+	session, err := handler.HandleChannelEvent(ctx, rt.DB, rt.RP, models.MOCallEventType, event, conn)
 	if err != nil {
 		logrus.WithError(err).WithField("http_request", r).Error("error handling incoming call")
 
@@ -155,7 +156,7 @@ func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w h
 		resumeURL := buildResumeURL(channel, conn, urn)
 
 		// have our client output our session status
-		err = client.WriteSessionResponse(ctx, s.RP, channel, conn, session, urn, resumeURL, r, w)
+		err = client.WriteSessionResponse(ctx, rt.RP, channel, conn, session, urn, resumeURL, r, w)
 		if err != nil {
 			return channel, conn, errors.Wrapf(err, "error writing ivr response for start")
 		}
@@ -166,13 +167,13 @@ func handleIncomingCall(ctx context.Context, s *web.Server, r *http.Request, w h
 	// no session means no trigger, create a missed call event instead
 	// we first create an incoming call channel event and see if that matches
 	event = models.NewChannelEvent(models.MOMissEventType, oa.OrgID(), channel.ID(), contact.ID(), urnID, nil, false)
-	err = event.Insert(ctx, s.DB)
+	err = event.Insert(ctx, rt.DB)
 	if err != nil {
 		return channel, conn, client.WriteErrorResponse(w, errors.Wrapf(err, "error inserting channel event"))
 	}
 
 	// try to handle it, this time looking for a missed call event
-	session, err = handler.HandleChannelEvent(ctx, s.DB, s.RP, models.MOMissEventType, event, nil)
+	session, err = handler.HandleChannelEvent(ctx, rt.DB, rt.RP, models.MOMissEventType, event, nil)
 	if err != nil {
 		logrus.WithError(err).WithField("http_request", r).Error("error handling missed call")
 		return channel, conn, client.WriteErrorResponse(w, errors.Wrapf(err, "error handling missed call"))
@@ -222,7 +223,7 @@ func buildResumeURL(channel *models.Channel, conn *models.ChannelConnection, urn
 }
 
 // handleFlow handles all incoming IVR requests related to a flow (status is handled elsewhere)
-func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
+func handleFlow(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*55)
 	defer cancel()
 
@@ -232,13 +233,13 @@ func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.Resp
 	}
 
 	// load our connection
-	conn, err := models.SelectChannelConnection(ctx, s.DB, request.ConnectionID)
+	conn, err := models.SelectChannelConnection(ctx, rt.DB, request.ConnectionID)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "unable to load channel connection with id: %d", request.ConnectionID)
 	}
 
 	// load our org assets
-	oa, err := models.GetOrgAssets(ctx, s.DB, conn.OrgID())
+	oa, err := models.GetOrgAssets(ctx, rt.DB, conn.OrgID())
 	if err != nil {
 		return nil, nil, writeClientError(w, errors.Wrapf(err, "error loading org assets"))
 	}
@@ -262,7 +263,7 @@ func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.Resp
 	}
 
 	// load our contact
-	contacts, err := models.LoadContacts(ctx, s.DB, oa, []models.ContactID{conn.ContactID()})
+	contacts, err := models.LoadContacts(ctx, rt.DB, oa, []models.ContactID{conn.ContactID()})
 	if err != nil {
 		return channel, conn, client.WriteErrorResponse(w, errors.Wrapf(err, "no such contact"))
 	}
@@ -274,7 +275,7 @@ func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.Resp
 	}
 
 	// load the URN for this connection
-	urn, err := models.URNForID(ctx, s.DB, oa, conn.ContactURNID())
+	urn, err := models.URNForID(ctx, rt.DB, oa, conn.ContactURNID())
 	if err != nil {
 		return channel, conn, client.WriteErrorResponse(w, errors.Errorf("unable to find connection urn: %d", conn.ContactURNID()))
 	}
@@ -296,21 +297,21 @@ func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.Resp
 	switch request.Action {
 	case actionStart:
 		err = ivr.StartIVRFlow(
-			ctx, s.DB, s.RP, client, resumeURL,
+			ctx, rt.DB, rt.RP, client, resumeURL,
 			oa, channel, conn, contacts[0], urn, conn.StartID(),
 			r, w,
 		)
 
 	case actionResume:
 		err = ivr.ResumeIVRFlow(
-			ctx, s.Config, s.DB, s.RP, s.Storage, resumeURL, client,
+			ctx, rt.Config, rt.DB, rt.RP, rt.Storage, resumeURL, client,
 			oa, channel, conn, contacts[0], urn,
 			r, w,
 		)
 
 	case actionStatus:
 		err = ivr.HandleIVRStatus(
-			ctx, s.DB, s.RP, oa, client, conn,
+			ctx, rt.DB, rt.RP, oa, client, conn,
 			r, w,
 		)
 
@@ -321,27 +322,27 @@ func handleFlow(ctx context.Context, s *web.Server, r *http.Request, w http.Resp
 	// had an error? mark our connection as errored and log it
 	if err != nil {
 		logrus.WithError(err).WithField("http_request", r).Error("error while handling IVR")
-		return channel, conn, ivr.WriteErrorResponse(ctx, s.DB, client, conn, w, err)
+		return channel, conn, ivr.WriteErrorResponse(ctx, rt.DB, client, conn, w, err)
 	}
 
 	return channel, conn, nil
 }
 
 // handleStatus handles all incoming IVR events / status updates
-func handleStatus(ctx context.Context, s *web.Server, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
+func handleStatus(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) (*models.Channel, *models.ChannelConnection, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*55)
 	defer cancel()
 
 	channelUUID := assets.ChannelUUID(chi.URLParam(r, "uuid"))
 
 	// load the org id for this UUID (we could load the entire channel here but we want to take the same paths through everything else)
-	orgID, err := models.OrgIDForChannelUUID(ctx, s.DB, channelUUID)
+	orgID, err := models.OrgIDForChannelUUID(ctx, rt.DB, channelUUID)
 	if err != nil {
 		return nil, nil, writeClientError(w, err)
 	}
 
 	// load our org assets
-	oa, err := models.GetOrgAssets(ctx, s.DB, orgID)
+	oa, err := models.GetOrgAssets(ctx, rt.DB, orgID)
 	if err != nil {
 		return nil, nil, writeClientError(w, errors.Wrapf(err, "error loading org assets"))
 	}
@@ -365,7 +366,7 @@ func handleStatus(ctx context.Context, s *web.Server, r *http.Request, w http.Re
 	}
 
 	// preprocess this status
-	body, err := client.PreprocessStatus(ctx, s.DB, s.RP, r)
+	body, err := client.PreprocessStatus(ctx, rt.DB, rt.RP, r)
 	if err != nil {
 		return channel, nil, client.WriteErrorResponse(w, errors.Wrapf(err, "error while preprocessing status"))
 	}
@@ -383,7 +384,7 @@ func handleStatus(ctx context.Context, s *web.Server, r *http.Request, w http.Re
 	}
 
 	// load our connection
-	conn, err := models.SelectChannelConnectionByExternalID(ctx, s.DB, channel.ID(), models.ConnectionTypeIVR, externalID)
+	conn, err := models.SelectChannelConnectionByExternalID(ctx, rt.DB, channel.ID(), models.ConnectionTypeIVR, externalID)
 	if errors.Cause(err) == sql.ErrNoRows {
 		return channel, nil, client.WriteEmptyResponse(w, "unknown connection, ignoring")
 	}
@@ -391,12 +392,12 @@ func handleStatus(ctx context.Context, s *web.Server, r *http.Request, w http.Re
 		return channel, nil, client.WriteErrorResponse(w, errors.Wrapf(err, "unable to load channel connection with id: %s", externalID))
 	}
 
-	err = ivr.HandleIVRStatus(ctx, s.DB, s.RP, oa, client, conn, r, w)
+	err = ivr.HandleIVRStatus(ctx, rt.DB, rt.RP, oa, client, conn, r, w)
 
 	// had an error? mark our connection as errored and log it
 	if err != nil {
 		logrus.WithError(err).WithField("http_request", r).Error("error while handling status")
-		return channel, conn, ivr.WriteErrorResponse(ctx, s.DB, client, conn, w, err)
+		return channel, conn, ivr.WriteErrorResponse(ctx, rt.DB, client, conn, w, err)
 	}
 
 	return channel, conn, nil

--- a/web/po/po.go
+++ b/web/po/po.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/goflow/utils/i18n"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/web"
 
 	"github.com/go-chi/chi/middleware"
@@ -38,13 +39,13 @@ type exportRequest struct {
 	ExcludeArguments bool            `json:"exclude_arguments"`
 }
 
-func handleExport(ctx context.Context, s *web.Server, r *http.Request, rawW http.ResponseWriter) error {
+func handleExport(ctx context.Context, rt *runtime.Runtime, r *http.Request, rawW http.ResponseWriter) error {
 	request := &exportRequest{}
 	if err := utils.UnmarshalAndValidateWithLimit(r.Body, request, web.MaxRequestBytes); err != nil {
 		return errors.Wrapf(err, "request failed validation")
 	}
 
-	flows, err := loadFlows(ctx, s.DB, request.OrgID, request.FlowIDs)
+	flows, err := loadFlows(ctx, rt.DB, request.OrgID, request.FlowIDs)
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ type importForm struct {
 	Language envs.Language   `form:"language" validate:"required"`
 }
 
-func handleImport(ctx context.Context, s *web.Server, r *http.Request) (interface{}, int, error) {
+func handleImport(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	form := &importForm{}
 	if err := web.DecodeAndValidateForm(form, r); err != nil {
 		return err, http.StatusBadRequest, nil
@@ -96,7 +97,7 @@ func handleImport(ctx context.Context, s *web.Server, r *http.Request) (interfac
 		return errors.Wrapf(err, "invalid po file"), http.StatusBadRequest, nil
 	}
 
-	flows, err := loadFlows(ctx, s.DB, form.OrgID, form.FlowIDs)
+	flows, err := loadFlows(ctx, rt.DB, form.OrgID, form.FlowIDs)
 	if err != nil {
 		return err, http.StatusBadRequest, nil
 	}

--- a/web/server.go
+++ b/web/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/storage"
 	"github.com/nyaruka/mailroom/config"
+	"github.com/nyaruka/mailroom/runtime"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -33,8 +34,8 @@ const (
 	MaxRequestBytes int64 = 1048576 * 32 // 32MB
 )
 
-type JSONHandler func(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error)
-type Handler func(ctx context.Context, s *Server, r *http.Request, w http.ResponseWriter) error
+type JSONHandler func(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error)
+type Handler func(ctx context.Context, rt *runtime.Runtime, r *http.Request, w http.ResponseWriter) error
 
 type jsonRoute struct {
 	method  string
@@ -61,14 +62,16 @@ func RegisterRoute(method string, pattern string, handler Handler) {
 }
 
 // NewServer creates a new web server, it will need to be started after being created
-func NewServer(ctx context.Context, config *config.Config, db *sqlx.DB, rp *redis.Pool, store storage.Storage, elasticClient *elastic.Client, wg *sync.WaitGroup) *Server {
+func NewServer(ctx context.Context, config *config.Config, db *sqlx.DB, rp *redis.Pool, store storage.Storage, es *elastic.Client, wg *sync.WaitGroup) *Server {
 	s := &Server{
-		CTX:           ctx,
-		RP:            rp,
-		DB:            db,
-		Storage:       store,
-		ElasticClient: elasticClient,
-		Config:        config,
+		ctx: ctx,
+		rt: &runtime.Runtime{
+			RP:      rp,
+			DB:      db,
+			ES:      es,
+			Storage: store,
+			Config:  config,
+		},
 
 		wg: wg,
 	}
@@ -115,7 +118,7 @@ func (s *Server) WrapJSONHandler(handler JSONHandler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-type", "application/json")
 
-		value, status, err := handler(r.Context(), s, r)
+		value, status, err := handler(r.Context(), s.rt, r)
 
 		// handler errored (a hard error)
 		if err != nil {
@@ -151,7 +154,7 @@ func (s *Server) WrapJSONHandler(handler JSONHandler) http.HandlerFunc {
 // WrapHandler wraps a simple Handler, taking care of passing down server and handling errors
 func (s *Server) WrapHandler(handler Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		err := handler(r.Context(), s, r, w)
+		err := handler(r.Context(), s.rt, r, w)
 		if err == nil {
 			return
 		}
@@ -180,7 +183,7 @@ func (s *Server) Start() {
 		}
 	}()
 
-	logrus.WithField("address", s.Config.Address).WithField("port", s.Config.Port).Info("server started")
+	logrus.WithField("address", s.rt.Config.Address).WithField("port", s.rt.Config.Port).Info("server started")
 }
 
 // Stop stops our web server
@@ -191,30 +194,26 @@ func (s *Server) Stop() {
 	}
 }
 
-func handleIndex(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
+func handleIndex(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	response := map[string]string{
 		"url":       fmt.Sprintf("%s", r.URL),
 		"component": "mailroom",
-		"version":   s.Config.Version,
+		"version":   rt.Config.Version,
 	}
 	return response, http.StatusOK, nil
 }
 
-func handle404(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
+func handle404(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	return errors.Errorf("not found: %s", r.URL.String()), http.StatusNotFound, nil
 }
 
-func handle405(ctx context.Context, s *Server, r *http.Request) (interface{}, int, error) {
+func handle405(ctx context.Context, rt *runtime.Runtime, r *http.Request) (interface{}, int, error) {
 	return errors.Errorf("illegal method: %s", r.Method), http.StatusMethodNotAllowed, nil
 }
 
 type Server struct {
-	CTX           context.Context
-	RP            *redis.Pool
-	DB            *sqlx.DB
-	Storage       storage.Storage
-	Config        *config.Config
-	ElasticClient *elastic.Client
+	ctx context.Context
+	rt  *runtime.Runtime
 
 	wg *sync.WaitGroup
 

--- a/web/wrappers_test.go
+++ b/web/wrappers_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nyaruka/gocommon/httpx"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/runtime"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 	"github.com/nyaruka/mailroom/web"
@@ -26,8 +27,8 @@ func TestWithHTTPLogs(t *testing.T) {
 		},
 	}))
 
-	handler := func(ctx context.Context, s *web.Server, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
-		ticketer, _ := models.LookupTicketerByUUID(ctx, s.DB, testdata.Mailgun.UUID)
+	handler := func(ctx context.Context, rt *runtime.Runtime, r *http.Request, l *models.HTTPLogger) (interface{}, int, error) {
+		ticketer, _ := models.LookupTicketerByUUID(ctx, rt.DB, testdata.Mailgun.UUID)
 
 		logger := l.Ticketer(ticketer)
 
@@ -48,9 +49,8 @@ func TestWithHTTPLogs(t *testing.T) {
 	}
 
 	// simulate handler being invoked by server
-	server := &web.Server{DB: testsuite.DB()}
 	wrapped := web.WithHTTPLogs(handler)
-	response, status, err := wrapped(testsuite.CTX(), server, nil)
+	response, status, err := wrapped(testsuite.CTX(), testsuite.Runtime(), nil)
 
 	// check response from handler
 	assert.Equal(t, map[string]string{"status": "OK"}, response)

--- a/web/wrappers_test.go
+++ b/web/wrappers_test.go
@@ -50,7 +50,7 @@ func TestWithHTTPLogs(t *testing.T) {
 
 	// simulate handler being invoked by server
 	wrapped := web.WithHTTPLogs(handler)
-	response, status, err := wrapped(testsuite.CTX(), testsuite.Runtime(), nil)
+	response, status, err := wrapped(testsuite.CTX(), testsuite.RT(), nil)
 
 	// check response from handler
 	assert.Equal(t, map[string]string{"status": "OK"}, response)

--- a/workers.go
+++ b/workers.go
@@ -3,16 +3,19 @@ package mailroom
 import (
 	"context"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/nyaruka/mailroom/runtime"
 
 	"github.com/sirupsen/logrus"
 )
 
 // Foreman takes care of managing our set of workers and assigns msgs for each to send
 type Foreman struct {
-	mr               *Mailroom
+	rt               *runtime.Runtime
+	wg               *sync.WaitGroup
 	queue            string
 	workers          []*Worker
 	availableWorkers chan *Worker
@@ -20,9 +23,10 @@ type Foreman struct {
 }
 
 // NewForeman creates a new Foreman for the passed in server with the number of max workers
-func NewForeman(mr *Mailroom, queue string, maxWorkers int) *Foreman {
+func NewForeman(rt *runtime.Runtime, wg *sync.WaitGroup, queue string, maxWorkers int) *Foreman {
 	foreman := &Foreman{
-		mr:               mr,
+		rt:               rt,
+		wg:               wg,
 		queue:            queue,
 		workers:          make([]*Worker, maxWorkers),
 		availableWorkers: make(chan *Worker, maxWorkers),
@@ -56,8 +60,8 @@ func (f *Foreman) Stop() {
 // Assign is our main loop for the Foreman, it takes care of popping the next outgoing task from our
 // backend and assigning them to workers
 func (f *Foreman) Assign() {
-	f.mr.WaitGroup.Add(1)
-	defer f.mr.WaitGroup.Done()
+	f.wg.Add(1)
+	defer f.wg.Done()
 	log := logrus.WithField("comp", "foreman")
 
 	log.WithFields(logrus.Fields{
@@ -78,7 +82,7 @@ func (f *Foreman) Assign() {
 		// otherwise, grab the next task and assign it to a worker
 		case worker := <-f.availableWorkers:
 			// see if we have a task to work on
-			rc := f.mr.RP.Get()
+			rc := f.rt.RP.Get()
 			task, err := queue.PopNextTask(rc, f.queue)
 			rc.Close()
 
@@ -123,10 +127,10 @@ func NewWorker(foreman *Foreman, id int) *Worker {
 
 // Start starts our Worker's goroutine and has it start waiting for tasks from the foreman
 func (w *Worker) Start() {
-	w.foreman.mr.WaitGroup.Add(1)
+	w.foreman.wg.Add(1)
 
 	go func() {
-		defer w.foreman.mr.WaitGroup.Done()
+		defer w.foreman.wg.Done()
 
 		log := logrus.WithField("queue", w.foreman.queue).WithField("worker_id", w.id)
 		log.Debug("started")
@@ -166,7 +170,7 @@ func (w *Worker) handleTask(task *queue.Task) {
 		}
 
 		// mark our task as complete
-		rc := w.foreman.mr.RP.Get()
+		rc := w.foreman.rt.RP.Get()
 		err := queue.MarkTaskComplete(rc, w.foreman.queue, task.OrgID)
 		if err != nil {
 			log.WithError(err)
@@ -179,7 +183,7 @@ func (w *Worker) handleTask(task *queue.Task) {
 
 	taskFunc, found := taskFunctions[task.Type]
 	if found {
-		err := taskFunc(context.Background(), w.foreman.mr, task)
+		err := taskFunc(context.Background(), w.foreman.rt, task)
 		if err != nil {
 			log.WithError(err).WithField("task", string(task.Task)).WithField("task_type", task.Type).WithField("org_id", task.OrgID).Error("error running task")
 		}


### PR DESCRIPTION
Added use in Mailroom and tasks as well. I think from here on out we can switch things over as needed.

Maybe rule is if you are passing more than just two items in the Runtime then pass Runtime instead. (IE, if you only care about db, pass that, or even if you use db and rp, pass those in, but if more than that pass in runtime)