### PR TITLE
Bit of reorganization in tasks/handler

### DIFF
--- a/cmd/mailroom/main.go
+++ b/cmd/mailroom/main.go
@@ -20,7 +20,6 @@ import (
 	_ "github.com/nyaruka/mailroom/core/tasks/campaigns"
 	_ "github.com/nyaruka/mailroom/core/tasks/contacts"
 	_ "github.com/nyaruka/mailroom/core/tasks/expirations"
-	_ "github.com/nyaruka/mailroom/core/tasks/groups"
 	_ "github.com/nyaruka/mailroom/core/tasks/interrupts"
 	_ "github.com/nyaruka/mailroom/core/tasks/ivr"
 	_ "github.com/nyaruka/mailroom/core/tasks/schedules"

--- a/core/runner/runner_test.go
+++ b/core/runner/runner_test.go
@@ -1,4 +1,4 @@
-package runner
+package runner_test
 
 import (
 	"encoding/json"
@@ -11,11 +11,13 @@ import (
 	"github.com/nyaruka/goflow/flows/triggers"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/runner"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCampaignStarts(t *testing.T) {
@@ -60,7 +62,7 @@ func TestCampaignStarts(t *testing.T) {
 			Scheduled: now,
 		},
 	}
-	sessions, err := FireCampaignEvents(ctx, db, rp, testdata.Org1.ID, fires, testdata.CampaignFlow.UUID, campaign, "e68f4c70-9db1-44c8-8498-602d6857235e")
+	sessions, err := runner.FireCampaignEvents(ctx, db, rp, testdata.Org1.ID, fires, testdata.CampaignFlow.UUID, campaign, "e68f4c70-9db1-44c8-8498-602d6857235e")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(sessions), "expected only two sessions to be created")
 
@@ -142,8 +144,8 @@ func TestBatchStart(t *testing.T) {
 			WithExtra(tc.Extra)
 		batch := start.CreateBatch(contactIDs, true, len(contactIDs))
 
-		sessions, err := StartFlowBatch(ctx, db, rp, batch)
-		assert.NoError(t, err)
+		sessions, err := runner.StartFlowBatch(ctx, db, rp, batch)
+		require.NoError(t, err)
 		assert.Equal(t, tc.Count, len(sessions), "%d: unexpected number of sessions created", i)
 
 		testsuite.AssertQueryCount(t, db,
@@ -178,20 +180,20 @@ func TestContactRuns(t *testing.T) {
 	rp := testsuite.RP()
 
 	oa, err := models.GetOrgAssets(ctx, db, testdata.Org1.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	flow, err := oa.FlowByID(testdata.Favorites.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// load our contact
 	contacts, err := models.LoadContacts(ctx, db, oa, []models.ContactID{testdata.Cathy.ID})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	contact, err := contacts[0].FlowContact(oa)
 	assert.NoError(t, err)
 
 	trigger := triggers.NewBuilder(oa.Env(), flow.FlowReference(), contact).Manual().Build()
-	sessions, err := StartFlowForContacts(ctx, db, rp, oa, flow, []flows.Trigger{trigger}, nil, true)
+	sessions, err := runner.StartFlowForContacts(ctx, db, rp, oa, flow, []flows.Trigger{trigger}, nil, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, sessions)
 
@@ -232,7 +234,7 @@ func TestContactRuns(t *testing.T) {
 		msg.SetID(10)
 		resume := resumes.NewMsg(oa.Env(), contact, msg)
 
-		session, err = ResumeFlow(ctx, db, rp, oa, session, resume, nil)
+		session, err = runner.ResumeFlow(ctx, db, rp, oa, session, resume, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 

--- a/core/tasks/base_test.go
+++ b/core/tasks/base_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
-	"github.com/nyaruka/mailroom/core/tasks/groups"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +18,7 @@ func TestReadTask(t *testing.T) {
 	}`))
 	require.NoError(t, err)
 
-	typedTask := task.(*groups.PopulateDynamicGroupTask)
+	typedTask := task.(*contacts.PopulateDynamicGroupTask)
 	assert.Equal(t, models.GroupID(23), typedTask.GroupID)
 	assert.Equal(t, "gender = F", typedTask.Query)
 }

--- a/core/tasks/contacts/populate_dynamic_group.go
+++ b/core/tasks/contacts/populate_dynamic_group.go
@@ -1,4 +1,4 @@
-package groups
+package contacts
 
 import (
 	"context"

--- a/core/tasks/contacts/populate_dynamic_group_test.go
+++ b/core/tasks/contacts/populate_dynamic_group_test.go
@@ -1,10 +1,10 @@
-package groups_test
+package contacts_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/nyaruka/mailroom/core/tasks/groups"
+	"github.com/nyaruka/mailroom/core/tasks/contacts"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 
@@ -56,7 +56,7 @@ func TestPopulateTask(t *testing.T) {
 
 	group := testdata.InsertContactGroup(t, db, testdata.Org1, "e52fee05-2f95-4445-aef6-2fe7dac2fd56", "Women", "gender = F")
 
-	task := &groups.PopulateDynamicGroupTask{
+	task := &contacts.PopulateDynamicGroupTask{
 		GroupID: group.ID,
 		Query:   "gender = F",
 	}

--- a/core/tasks/expirations/cron.go
+++ b/core/tasks/expirations/cron.go
@@ -108,7 +108,7 @@ func expireRuns(ctx context.Context, db *sqlx.DB, rp *redis.Pool, lockName strin
 
 		// ok, queue this task
 		task := handler.NewExpirationTask(expiration.OrgID, expiration.ContactID, *expiration.SessionID, expiration.RunID, expiration.ExpiresOn)
-		err = handler.AddHandleTask(rc, expiration.ContactID, task)
+		err = handler.QueueHandleTask(rc, expiration.ContactID, task)
 		if err != nil {
 			return errors.Wrapf(err, "error adding new expiration task")
 		}

--- a/core/tasks/handler/cron.go
+++ b/core/tasks/handler/cron.go
@@ -36,14 +36,14 @@ func StartRetryCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) err
 		func(lockName string, lockValue string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
-			return retryPendingMsgs(ctx, rt.DB, rt.RP, lockName, lockValue)
+			return RetryPendingMsgs(ctx, rt.DB, rt.RP, lockName, lockValue)
 		},
 	)
 	return nil
 }
 
-// retryPendingMsgs looks for any pending msgs older than five minutes and queues them to be handled again
-func retryPendingMsgs(ctx context.Context, db *sqlx.DB, rp *redis.Pool, lockName string, lockValue string) error {
+// RetryPendingMsgs looks for any pending msgs older than five minutes and queues them to be handled again
+func RetryPendingMsgs(ctx context.Context, db *sqlx.DB, rp *redis.Pool, lockName string, lockValue string) error {
 	if !config.Mailroom.RetryPendingMessages {
 		return nil
 	}
@@ -106,7 +106,7 @@ func retryPendingMsgs(ctx context.Context, db *sqlx.DB, rp *redis.Pool, lockName
 		}
 
 		// queue this event up for handling
-		err = AddHandleTask(rc, contactID, task)
+		err = QueueHandleTask(rc, contactID, task)
 		if err != nil {
 			return errors.Wrapf(err, "error queuing retry for task")
 		}

--- a/core/tasks/handler/queue.go
+++ b/core/tasks/handler/queue.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/queue"
+	"github.com/pkg/errors"
+)
+
+// QueueHandleTask queues a single task for the given contact
+func QueueHandleTask(rc redis.Conn, contactID models.ContactID, task *queue.Task) error {
+	return queueHandleTask(rc, contactID, task, false)
+}
+
+// queueHandleTask queues a single task for the passed in contact. `front` specifies whether the task
+// should be inserted in front of all other tasks for that contact
+func queueHandleTask(rc redis.Conn, contactID models.ContactID, task *queue.Task, front bool) error {
+	// marshal our task
+	taskJSON, err := json.Marshal(task)
+	if err != nil {
+		return errors.Wrapf(err, "error marshalling contact task")
+	}
+
+	// first push the event on our contact queue
+	contactQ := fmt.Sprintf("c:%d:%d", task.OrgID, contactID)
+	if front {
+		_, err = redis.Int64(rc.Do("lpush", contactQ, string(taskJSON)))
+
+	} else {
+		_, err = redis.Int64(rc.Do("rpush", contactQ, string(taskJSON)))
+	}
+	if err != nil {
+		return errors.Wrapf(err, "error adding contact event")
+	}
+
+	return queueContactTask(rc, models.OrgID(task.OrgID), contactID)
+}
+
+// pushes a single contact task on our queue. Note this does not push the actual content of the task
+// only that a task exists for the contact, addHandleTask should be used if the task has already been pushed
+// off the contact specific queue.
+func queueContactTask(rc redis.Conn, orgID models.OrgID, contactID models.ContactID) error {
+	// create our contact event
+	contactTask := &HandleEventTask{ContactID: contactID}
+
+	// then add a handle task for that contact on our global handler queue
+	err := queue.AddTask(rc, queue.HandlerQueue, queue.HandleContactEvent, int(orgID), contactTask, queue.DefaultPriority)
+	if err != nil {
+		return errors.Wrapf(err, "error adding handle event task")
+	}
+	return nil
+}

--- a/core/tasks/timeouts/cron.go
+++ b/core/tasks/timeouts/cron.go
@@ -79,7 +79,7 @@ func timeoutSessions(ctx context.Context, db *sqlx.DB, rp *redis.Pool, lockName 
 
 		// ok, queue this task
 		task := handler.NewTimeoutTask(timeout.OrgID, timeout.ContactID, timeout.SessionID, timeout.TimeoutOn)
-		err = handler.AddHandleTask(rc, timeout.ContactID, task)
+		err = handler.QueueHandleTask(rc, timeout.ContactID, task)
 		if err != nil {
 			return errors.Wrapf(err, "error adding new handle task")
 		}

--- a/web/simulation/simulation_test.go
+++ b/web/simulation/simulation_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nyaruka/mailroom/config"
+	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 	"github.com/nyaruka/mailroom/web"
@@ -266,20 +267,10 @@ func TestServer(t *testing.T) {
 	session := ""
 
 	// add a trigger for our campaign flow with 'trigger'
-	db.MustExec(
-		`INSERT INTO triggers_trigger(is_active, created_on, modified_on, keyword, is_archived, 
-									  flow_id, trigger_type, match_type, created_by_id, modified_by_id, org_id)
-		VALUES(TRUE, now(), now(), 'trigger', false, $1, 'K', 'O', 1, 1, 1) RETURNING id`,
-		testdata.CampaignFlow.ID,
-	)
+	testdata.InsertKeywordTrigger(t, db, testdata.Org1, testdata.CampaignFlow, "trigger", models.MatchOnly, nil, nil)
 
 	// also add a catch all
-	db.MustExec(
-		`INSERT INTO triggers_trigger(is_active, created_on, modified_on, keyword, is_archived, 
-									  flow_id, trigger_type, match_type, created_by_id, modified_by_id, org_id)
-		VALUES(TRUE, now(), now(), NULL, false, $1, 'C', NULL, 1, 1, 1) RETURNING id`,
-		testdata.CampaignFlow.ID,
-	)
+	testdata.InsertCatchallTrigger(t, db, testdata.Org1, testdata.CampaignFlow, nil, nil)
 
 	tcs := []struct {
 		URL      string


### PR DESCRIPTION
In the course of trying to add the closed-ticket event handling stuff ran into some issues that require a bit of re-organization first. One thing we don't do currently is queue handler events from outside that package, so need to figure out a good pattern for how other packages interact with that queue.

* Convert `core/runner/runner_test` and `tasks/handler/worker_test` to blackbox tests to break dependency on `core/handlers` from `task/handler`
* Split up code that handles handler tasks from code that queues handler tasks
* Move `tasks/groups/populate_dynamic_group` into `tasks/contacts` as it doesn't warrant its own package