### PR TITLE
Don't write output when writing to s3

### DIFF
--- a/core/models/orgs.go
+++ b/core/models/orgs.go
@@ -68,9 +68,8 @@ const (
 
 	configSessionStorageMode = "session_storage_mode"
 
-	DBSessions      = SessionStorageMode("db")
-	S3Sessions      = SessionStorageMode("s3")
-	S3WriteSessions = SessionStorageMode("s3_write")
+	DBSessions = SessionStorageMode("db")
+	S3Sessions = SessionStorageMode("s3")
 )
 
 // Org is mailroom's type for RapidPro orgs. It also implements the envs.Environment interface for GoFlow

--- a/core/runner/runner_test.go
+++ b/core/runner/runner_test.go
@@ -220,7 +220,7 @@ func TestResume(t *testing.T) {
 
 		testsuite.AssertQuery(t, db,
 			`SELECT count(*) FROM flows_flowsession WHERE contact_id = $1 AND current_flow_id = $2
-			 AND status = $3 AND responded = TRUE AND org_id = 1 AND connection_id IS NULL AND output IS NOT NULL AND output_url IS NOT NULL`, contact.ID(), flow.ID(), tc.SessionStatus).
+			 AND status = $3 AND responded = TRUE AND org_id = 1 AND connection_id IS NULL AND output IS NULL AND output_url IS NOT NULL`, contact.ID(), flow.ID(), tc.SessionStatus).
 			Returns(1, "%d: didn't find expected session", i)
 
 		runIsActive := tc.RunStatus == models.RunStatusActive || tc.RunStatus == models.RunStatusWaiting

--- a/core/runner/runner_test.go
+++ b/core/runner/runner_test.go
@@ -167,7 +167,7 @@ func TestResume(t *testing.T) {
 
 	defer testsuite.ResetStorage()
 
-	// write sessions to storage as well
+	// write sessions to s3 storage
 	db.MustExec(`UPDATE orgs_org set config = '{"session_storage_mode": "s3"}' WHERE id = 1`)
 	defer testsuite.ResetDB()
 
@@ -186,7 +186,7 @@ func TestResume(t *testing.T) {
 
 	testsuite.AssertQuery(t, db,
 		`SELECT count(*) FROM flows_flowsession WHERE contact_id = $1 AND current_flow_id = $2
-		 AND status = 'W' AND responded = FALSE AND org_id = 1 AND connection_id IS NULL AND output IS NOT NULL`, contact.ID(), flow.ID()).Returns(1)
+		 AND status = 'W' AND responded = FALSE AND org_id = 1 AND connection_id IS NULL AND output IS NULL`, contact.ID(), flow.ID()).Returns(1)
 
 	testsuite.AssertQuery(t, db,
 		`SELECT count(*) FROM flows_flowrun WHERE contact_id = $1 AND flow_id = $2


### PR DESCRIPTION
Once we turn this on we should see DB usage drop significantly, but it means no going back! Probably good to flip some orgs to writing S3 first (in addition to DB) to make sure performance isn't dropping too much from latency before flipping this on.