### PR TITLE
Explicitly exclude msg fields from marshaling that courier doesn't use

### DIFF
--- a/core/models/msgs.go
+++ b/core/models/msgs.go
@@ -106,7 +106,7 @@ type Msg struct {
 		Direction            MsgDirection       `db:"direction"       json:"direction"`
 		Status               MsgStatus          `db:"status"          json:"status"`
 		Visibility           MsgVisibility      `db:"visibility"      json:"visibility"`
-		MsgType              MsgType            `db:"msg_type"`
+		MsgType              MsgType            `db:"msg_type"        json:"-"`
 		MsgCount             int                `db:"msg_count"       json:"tps_cost"`
 		ErrorCount           int                `db:"error_count"     json:"error_count"`
 		NextAttempt          *time.Time         `db:"next_attempt"    json:"next_attempt"`
@@ -115,7 +115,7 @@ type Msg struct {
 		Metadata             null.Map           `db:"metadata"        json:"metadata,omitempty"`
 		ChannelID            ChannelID          `db:"channel_id"      json:"channel_id"`
 		ChannelUUID          assets.ChannelUUID `                     json:"channel_uuid"`
-		ConnectionID         *ConnectionID      `db:"connection_id"`
+		ConnectionID         *ConnectionID      `db:"connection_id"   json:"-"`
 		ContactID            ContactID          `db:"contact_id"      json:"contact_id"`
 		ContactURNID         *URNID             `db:"contact_urn_id"  json:"contact_urn_id"`
 		ResponseToID         MsgID              `db:"response_to_id"  json:"response_to_id"`
@@ -124,7 +124,7 @@ type Msg struct {
 		URN                  urns.URN           `                     json:"urn"`
 		URNAuth              null.String        `                     json:"urn_auth,omitempty"`
 		OrgID                OrgID              `db:"org_id"          json:"org_id"`
-		TopupID              TopupID            `db:"topup_id"`
+		TopupID              TopupID            `db:"topup_id"        json:"-"`
 
 		SessionID     SessionID     `json:"session_id,omitempty"`
 		SessionStatus SessionStatus `json:"session_status,omitempty"`

--- a/core/models/msgs_test.go
+++ b/core/models/msgs_test.go
@@ -1,15 +1,18 @@
 package models_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/urns"
 	"github.com/nyaruka/goflow/assets"
 	"github.com/nyaruka/goflow/envs"
 	"github.com/nyaruka/goflow/flows"
+	"github.com/nyaruka/goflow/test"
 	"github.com/nyaruka/goflow/utils"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -21,6 +24,11 @@ import (
 
 func TestOutgoingMsgs(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
+
+	defer func() {
+		testsuite.Reset(testsuite.ResetData)
+		db.MustExec(`UPDATE orgs_org SET is_suspended = FALSE`)
+	}()
 
 	tcs := []struct {
 		ChannelUUID  assets.ChannelUUID
@@ -91,9 +99,6 @@ func TestOutgoingMsgs(t *testing.T) {
 	now := time.Now()
 
 	for _, tc := range tcs {
-		tx, err := db.BeginTxx(ctx, nil)
-		require.NoError(t, err)
-
 		db.MustExec(`UPDATE orgs_org SET is_suspended = $1 WHERE id = $2`, tc.SuspendedOrg, testdata.Org1.ID)
 
 		oa, err := models.GetOrgAssetsWithRefresh(ctx, rt, testdata.Org1.ID, models.RefreshOrg)
@@ -109,7 +114,7 @@ func TestOutgoingMsgs(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 
-			err = models.InsertMessages(ctx, tx, []*models.Msg{msg})
+			err = models.InsertMessages(ctx, db, []*models.Msg{msg})
 			assert.NoError(t, err)
 			assert.Equal(t, oa.OrgID(), msg.OrgID())
 			assert.Equal(t, tc.Text, msg.Text())
@@ -131,8 +136,6 @@ func TestOutgoingMsgs(t *testing.T) {
 			assert.True(t, msg.QueuedOn().After(now))
 			assert.True(t, msg.ModifiedOn().After(now))
 		}
-
-		tx.Rollback()
 	}
 }
 
@@ -145,6 +148,73 @@ func TestGetMessageIDFromUUID(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, models.MsgID(msgIn.ID()), msgID)
+
+}
+
+func TestMarshalMsg(t *testing.T) {
+	ctx, rt, db, _ := testsuite.Get()
+
+	testsuite.AssertQuery(t, db, `SELECT count(*) FROM orgs_org WHERE is_suspended = TRUE`).Returns(0)
+
+	oa, err := models.GetOrgAssets(ctx, rt, testdata.Org1.ID)
+	require.NoError(t, err)
+	require.False(t, oa.Org().Suspended())
+
+	channel := oa.ChannelByUUID(testdata.TwilioChannel.UUID)
+	urn := urns.URN(fmt.Sprintf("tel:+250700000001?id=%d", testdata.Cathy.URNID))
+	flowMsg := flows.NewMsgOut(
+		urn,
+		assets.NewChannelReference(testdata.TwilioChannel.UUID, "Test Channel"),
+		"Hi there",
+		[]utils.Attachment{utils.Attachment("image/jpeg:https://dl-foo.com/image.jpg")},
+		[]string{"yes", "no"},
+		nil,
+		flows.MsgTopicPurchase,
+	)
+	msg, err := models.NewOutgoingMsg(rt.Config, oa.Org(), channel, testdata.Cathy.ID, flowMsg, time.Date(2021, 11, 9, 14, 3, 30, 0, time.UTC))
+	require.NoError(t, err)
+
+	err = models.InsertMessages(ctx, db, []*models.Msg{msg})
+	require.NoError(t, err)
+
+	marshaled, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	test.AssertEqualJSON(t, []byte(fmt.Sprintf(`{
+		"attachments": [
+			"image/jpeg:https://dl-foo.com/image.jpg"
+		],
+		"channel_id": 10000,
+		"channel_uuid": "74729f45-7f29-4868-9dc4-90e491e3c7d8",
+		"contact_id": 10000,
+		"contact_urn_id": 10000,
+		"created_on": "2021-11-09T14:03:30Z",
+		"direction": "O",
+		"error_count": 0,
+		"external_id": null,
+		"high_priority": false,
+		"id": %d,
+		"metadata": {
+			"quick_replies": [
+				"yes",
+				"no"
+			],
+			"topic": "purchase"
+		},
+		"modified_on": %s,
+		"next_attempt": null,
+		"org_id": 1,
+		"queued_on": %s,
+		"response_to_external_id": null,
+		"response_to_id": null,
+		"sent_on": null,
+		"status": "Q",
+		"text": "Hi there",
+		"tps_cost": 2,
+		"urn": "tel:+250700000001?id=10000",
+		"uuid": "%s",
+		"visibility": "V"
+	}`, msg.ID(), jsonx.MustMarshal(msg.ModifiedOn()), jsonx.MustMarshal(msg.QueuedOn()), msg.UUID())), marshaled)
 }
 
 func TestLoadMessages(t *testing.T) {

--- a/core/models/tickets.go
+++ b/core/models/tickets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -479,7 +478,6 @@ func TicketsChangeTopic(ctx context.Context, db Queryer, oa *OrgAssets, userID U
 	now := dates.Now()
 
 	for _, ticket := range tickets {
-		fmt.Printf("ticket #%d topic=%d\n", ticket.ID(), ticket.TopicID())
 		if ticket.TopicID() != topicID {
 			ids = append(ids, ticket.ID())
 			t := &ticket.t


### PR DESCRIPTION
Poking around at courier queues I noticed the message json has fields like `MsgType`, `ConnectionID` and `TopupID` which don't belong there.

```
	{
		"direction":"O",
		"modified_on":"2021-11-09T18:39:55.038607Z",
		"contact_urn_id":59726291,
		"session_id":970967356,
		"external_id":null,
		"MsgType":"F",
		"attachments":null,
                ...
```