### PR TITLE
Health tracker utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   go-version: '1.17.x'
   postgis-version: '3.1'
+  redis-version: '3.2.4'
 jobs:
   test:
     name: Test
@@ -17,7 +18,7 @@ jobs:
     - name: Install Redis
       uses: zhulik/redis-action@v1.0.0
       with:
-        redis version: '5'
+        redis version: ${{ env.redis-version }}
 
     - name: Install PostgreSQL
       uses: nyaruka/postgis-action@v2

--- a/testsuite/assert.go
+++ b/testsuite/assert.go
@@ -62,6 +62,42 @@ func AssertContactTasks(t *testing.T, orgID models.OrgID, contactID models.Conta
 	test.AssertEqualJSON(t, expectedJSON, actualJSON, "")
 }
 
+func AssertRedisNotExists(t *testing.T, rp *redis.Pool, key string, msgAndArgs ...interface{}) {
+	rc := rp.Get()
+	defer rc.Close()
+
+	exists, err := redis.Int(rc.Do("EXISTS", key))
+	require.NoError(t, err)
+	assert.Equal(t, 0, exists, msgAndArgs...)
+}
+
+func AssertRedisInt(t *testing.T, rp *redis.Pool, key string, expected int, msgAndArgs ...interface{}) {
+	rc := rp.Get()
+	defer rc.Close()
+
+	actual, err := redis.Int(rc.Do("GET", key))
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual, msgAndArgs...)
+}
+
+func AssertRedisString(t *testing.T, rp *redis.Pool, key string, expected string, msgAndArgs ...interface{}) {
+	rc := rp.Get()
+	defer rc.Close()
+
+	actual, err := redis.String(rc.Do("GET", key))
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual, msgAndArgs...)
+}
+
+func AssertRedisSet(t *testing.T, rp *redis.Pool, key string, expected []string, msgAndArgs ...interface{}) {
+	rc := rp.Get()
+	defer rc.Close()
+
+	actual, err := redis.Strings(rc.Do("SMEMBERS", key))
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual, msgAndArgs...)
+}
+
 // AssertQuery creates a new query on which one can assert things
 func AssertQuery(t *testing.T, db *sqlx.DB, sql string, args ...interface{}) *Query {
 	return &Query{t, db, sql, args}

--- a/testsuite/assert.go
+++ b/testsuite/assert.go
@@ -29,7 +29,7 @@ func AssertCourierQueues(t *testing.T, expected map[string][]int, errMsg ...inte
 		actual[queueKey] = make([]int, size)
 
 		if size > 0 {
-			results, err := redis.Values(rc.Do("ZPOPMAX", queueKey, size))
+			results, err := redis.Values(rc.Do("ZRANGE", queueKey, "-inf", "+inf", "BYSCORE", "WITHSCORES"))
 			require.NoError(t, err)
 			require.Equal(t, int(size*2), len(results)) // result is (item, score, item, score, ...)
 

--- a/utils/redisx/tracker.go
+++ b/utils/redisx/tracker.go
@@ -9,22 +9,23 @@ import (
 	"github.com/nyaruka/gocommon/dates"
 )
 
-// BoolTracker is a tracker for bool results
-type BoolTracker struct {
-	keyBase  string        // e.g. channel:23
+// StatesTracker is a tracker for bool results
+type StatesTracker struct {
+	keyBase  string // e.g. channel:23
+	states   []string
 	interval time.Duration // e.g. 5 minutes
 	window   time.Duration // e.g. 30 minutes
 }
 
-// NewBool creates a new bool tracker
-func NewBoolTracker(keyBase string, interval time.Duration, window time.Duration) *BoolTracker {
-	return &BoolTracker{keyBase: keyBase, interval: interval, window: window}
+// NewStatesTracker creates a new states tracker
+func NewStatesTracker(keyBase string, states []string, interval time.Duration, window time.Duration) *StatesTracker {
+	return &StatesTracker{keyBase: keyBase, states: states, interval: interval, window: window}
 }
 
 // Record records a bool result
-func (t *BoolTracker) Record(rc redis.Conn, b bool) error {
-	its := t.getIntervalStart(dates.Now().Unix(), 0)
-	key := t.getCountKey(its, b)
+func (t *StatesTracker) Record(rc redis.Conn, s string) error {
+	its := t.getIntervalStart(dates.Now(), 0)
+	key := t.getCountKey(its, s)
 	exp := time.Unix(its, 0).Add(-t.window)
 
 	rc.Send("MULTI")
@@ -34,46 +35,79 @@ func (t *BoolTracker) Record(rc redis.Conn, b bool) error {
 	return err
 }
 
-// Current returns the current totals of true and false results
-func (t *BoolTracker) Current(rc redis.Conn) (int, int, error) {
-	from := dates.Now().Add(-t.window).Unix()
+// Current returns the current totals of all states
+func (t *StatesTracker) Current(rc redis.Conn) (map[string]int, error) {
+	now := dates.Now()
+	from := now.Add(-t.window).Unix()
 
 	// build a list of keys of each available interval in pairs of ..:yes, ..:no
 	keys := make([]interface{}, 0, 20)
 
 	for i := 0; ; i-- {
-		ts := t.getIntervalStart(dates.Now().Unix(), i)
+		ts := t.getIntervalStart(now, i)
 		if ts < from {
 			break
 		}
 
-		keys = append(keys, t.getCountKey(ts, true), t.getCountKey(ts, false))
+		for _, s := range t.states {
+			keys = append(keys, t.getCountKey(ts, s))
+		}
 	}
 
 	counts, err := redis.Ints(rc.Do("MGET", keys...))
 	if err != nil {
-		return 0, 0, err
+		return nil, err
 	}
 
-	totalTrue := 0
-	totalFalse := 0
-	for i, c := range counts {
-		if i%2 == 0 {
-			totalTrue += c
-		} else {
-			totalFalse += c
+	totals := make(map[string]int, len(t.states))
+
+	for i := 0; i < len(counts); i += len(t.states) {
+		for j, s := range t.states {
+			totals[s] += counts[i+j]
 		}
 	}
 
-	return totalTrue, totalFalse, nil
+	return totals, nil
 }
 
-func (t *BoolTracker) getCountKey(ts int64, b bool) string {
-	return fmt.Sprintf("%s:%d:%s", t.keyBase, ts, strconv.FormatBool(b))
+func (t *StatesTracker) getCountKey(ts int64, s string) string {
+	return fmt.Sprintf("%s:%d:%s", t.keyBase, ts, s)
 }
 
 // gets the timestamp for the start of an interval where 0 is the current, -1 the previous etc
-func (t *BoolTracker) getIntervalStart(nowTS int64, delta int) int64 {
+func (t *StatesTracker) getIntervalStart(now time.Time, delta int) int64 {
 	intervalSecs := int64(t.interval / time.Second)
-	return ((nowTS / intervalSecs) + int64(delta)) * intervalSecs
+	return ((now.Unix() / intervalSecs) + int64(delta)) * intervalSecs
+}
+
+// BoolTracker is a tracker for bool results
+type BoolTracker struct {
+	StatesTracker
+}
+
+// NewBoolTracker creates a new bool tracker
+func NewBoolTracker(keyBase string, interval time.Duration, window time.Duration) *BoolTracker {
+	return &BoolTracker{
+		StatesTracker: StatesTracker{
+			keyBase:  keyBase,
+			states:   []string{"true", "false"},
+			interval: interval,
+			window:   window,
+		},
+	}
+}
+
+// Record records a bool result
+func (t *BoolTracker) Record(rc redis.Conn, b bool) error {
+	return t.StatesTracker.Record(rc, strconv.FormatBool(b))
+}
+
+// Current returns the current totals of true and false results
+func (t *BoolTracker) Current(rc redis.Conn) (int, int, error) {
+	totals, err := t.StatesTracker.Current(rc)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return totals["true"], totals["false"], nil
 }

--- a/utils/redisx/tracker.go
+++ b/utils/redisx/tracker.go
@@ -1,0 +1,79 @@
+package redisx
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/gocommon/dates"
+)
+
+// BoolTracker is a tracker for bool results
+type BoolTracker struct {
+	keyBase  string        // e.g. channel:23
+	interval time.Duration // e.g. 5 minutes
+	window   time.Duration // e.g. 30 minutes
+}
+
+// NewBool creates a new bool tracker
+func NewBoolTracker(keyBase string, interval time.Duration, window time.Duration) *BoolTracker {
+	return &BoolTracker{keyBase: keyBase, interval: interval, window: window}
+}
+
+// Record records a bool result
+func (t *BoolTracker) Record(rc redis.Conn, b bool) error {
+	its := t.getIntervalStart(dates.Now().Unix(), 0)
+	key := t.getCountKey(its, b)
+	exp := time.Unix(its, 0).Add(-t.window)
+
+	rc.Send("MULTI")
+	rc.Send("INCR", key)
+	rc.Send("EXPIREAT", key, exp)
+	_, err := rc.Do("EXEC")
+	return err
+}
+
+// Current returns the current totals of true and false results
+func (t *BoolTracker) Current(rc redis.Conn) (int, int, error) {
+	from := dates.Now().Add(-t.window).Unix()
+
+	// build a list of keys of each available interval in pairs of ..:yes, ..:no
+	keys := make([]interface{}, 0, 20)
+
+	for i := 0; ; i-- {
+		ts := t.getIntervalStart(dates.Now().Unix(), i)
+		if ts < from {
+			break
+		}
+
+		keys = append(keys, t.getCountKey(ts, true), t.getCountKey(ts, false))
+	}
+
+	counts, err := redis.Ints(rc.Do("MGET", keys...))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	totalTrue := 0
+	totalFalse := 0
+	for i, c := range counts {
+		if i%2 == 0 {
+			totalTrue += c
+		} else {
+			totalFalse += c
+		}
+	}
+
+	return totalTrue, totalFalse, nil
+}
+
+func (t *BoolTracker) getCountKey(ts int64, b bool) string {
+	return fmt.Sprintf("%s:%d:%s", t.keyBase, ts, strconv.FormatBool(b))
+}
+
+// gets the timestamp for the start of an interval where 0 is the current, -1 the previous etc
+func (t *BoolTracker) getIntervalStart(nowTS int64, delta int) int64 {
+	intervalSecs := int64(t.interval / time.Second)
+	return ((nowTS / intervalSecs) + int64(delta)) * intervalSecs
+}

--- a/utils/redisx/tracker_test.go
+++ b/utils/redisx/tracker_test.go
@@ -1,0 +1,61 @@
+package redisx_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/utils/redisx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolTracker(t *testing.T) {
+	_, _, _, rp := testsuite.Get()
+	rc := rp.Get()
+	defer rc.Close()
+
+	defer testsuite.Reset(testsuite.ResetRedis)
+
+	defer dates.SetNowSource(dates.DefaultNowSource)
+	dates.SetNowSource(dates.NewFixedNowSource(time.Date(2021, 11, 18, 12, 0, 1, 234567, time.UTC)))
+
+	tr := redisx.NewBoolTracker("foo:1", time.Second*10, time.Second*30)
+
+	yes, no, err := tr.Current(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, yes)
+	assert.Equal(t, 0, no)
+
+	err = tr.Record(rc, true)
+	require.NoError(t, err)
+
+	tr.Record(rc, false)
+	tr.Record(rc, true)
+
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:true", 2)
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:false", 1)
+
+	yes, no, err = tr.Current(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, yes)
+	assert.Equal(t, 1, no)
+
+	dates.SetNowSource(dates.NewFixedNowSource(time.Date(2021, 11, 18, 12, 0, 13, 234567, time.UTC)))
+
+	tr.Record(rc, false)
+	tr.Record(rc, true)
+	tr.Record(rc, true)
+	tr.Record(rc, true)
+
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:true", 2)
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:false", 1)
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236810:true", 3)
+	testsuite.AssertRedisInt(t, rp, "foo:1:1637236810:false", 1)
+
+	yes, no, err = tr.Current(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, yes)
+	assert.Equal(t, 2, no)
+}

--- a/utils/redisx/tracker_test.go
+++ b/utils/redisx/tracker_test.go
@@ -19,29 +19,38 @@ func TestStatesTracker(t *testing.T) {
 	defer testsuite.Reset(testsuite.ResetRedis)
 
 	defer dates.SetNowSource(dates.DefaultNowSource)
-	dates.SetNowSource(dates.NewFixedNowSource(time.Date(2021, 11, 18, 12, 0, 1, 234567, time.UTC)))
+	setNow := func(d time.Time) { dates.SetNowSource(dates.NewFixedNowSource(d)) }
 
+	// create a states tracker with interval of 10 seconds and window of 30
 	tr := redisx.NewStatesTracker("foo:1", []string{"yes", "no", "maybe"}, time.Second*10, time.Second*30)
 
+	// set now to 12:00:03.. so current interval is 12:00:00 (1637236800) <= t < 12:00:10 (1637236810)
+	setNow(time.Date(2021, 11, 18, 12, 0, 3, 234567, time.UTC))
+
+	// no counts.. zeros for all
 	totals, err := tr.Current(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]int{"yes": 0, "no": 0, "maybe": 0}, totals)
 
-	err = tr.Record(rc, "yes")
-	require.NoError(t, err)
-
-	tr.Record(rc, "no")
-	tr.Record(rc, "yes")
+	require.NoError(t, tr.Record(rc, "yes"))
+	require.NoError(t, tr.Record(rc, "no"))
+	require.NoError(t, tr.Record(rc, "yes"))
 
 	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:yes", 2)
 	testsuite.AssertRedisInt(t, rp, "foo:1:1637236800:no", 1)
 	testsuite.AssertRedisNotExists(t, rp, "foo:1:1637236800:maybe")
 
+	// current window is 11:59:33 (1637236773) - 12:00:03 (1637236803) so we'll include counts from intervals..
+	//  0: 12:00:00 (1637236800) <= t < 12:00:10 (1637236810) yes=2 no=1 maybe=0
+	// -1: 11:59:50 (1637236790) <= t < 12:00:00 (1637236800) yes=0 no=0 maybe=0
+	// -2: 11:59:40 (1637236780) <= t < 11:59:50 (1637236790) yes=0 no=0 maybe=0
+	// -3: 11:59:30 (1637236770) <= t < 11:59:40 (1637236780) yes=0 no=0 maybe=0
 	totals, err = tr.Current(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]int{"yes": 2, "no": 1, "maybe": 0}, totals)
 
-	dates.SetNowSource(dates.NewFixedNowSource(time.Date(2021, 11, 18, 12, 0, 13, 234567, time.UTC)))
+	// set now to exactly 12:00:10 which falls on the start of a new interval
+	setNow(time.Date(2021, 11, 18, 12, 0, 10, 0, time.UTC))
 
 	tr.Record(rc, "no")
 	tr.Record(rc, "maybe")
@@ -55,9 +64,30 @@ func TestStatesTracker(t *testing.T) {
 	testsuite.AssertRedisInt(t, rp, "foo:1:1637236810:no", 1)
 	testsuite.AssertRedisInt(t, rp, "foo:1:1637236810:maybe", 1)
 
+	// current window is 11:40:00 (1637236780) - 12:00:10 (1637236810) so we'll include counts from intervals..
+	//  0: 12:00:10 (1637236810) <= t < 12:00:20 (1637236820) yes=3 no=1 maybe=1
+	// -1: 12:00:00 (1637236800) <= t < 12:00:10 (1637236810) yes=2 no=1 maybe=0
+	// -2: 11:59:50 (1637236790) <= t < 12:00:00 (1637236800) yes=0 no=0 maybe=0
+	// -3: 11:59:40 (1637236780) <= t < 11:59:50 (1637236790) yes=0 no=0 maybe=0
 	totals, err = tr.Current(rc)
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]int{"yes": 5, "no": 2, "maybe": 1}, totals)
+
+	// set now to 12:00:35
+	setNow(time.Date(2021, 11, 18, 12, 0, 35, 0, time.UTC))
+
+	tr.Record(rc, "no")
+	tr.Record(rc, "yes")
+	tr.Record(rc, "yes")
+
+	// current window is 12:00:05 (1637236805) - 12:00:35 (1637236835) so we'll include counts from intervals..
+	//  0: 12:00:30 (1637236810) <= t < 12:00:40 (1637236820) yes=2 no=1 maybe=0
+	// -1: 12:00:20 (1637236800) <= t < 12:00:30 (1637236810) yes=0 no=0 maybe=0
+	// -2: 12:00:10 (1637236790) <= t < 12:00:20 (1637236800) yes=3 no=1 maybe=1
+	// -3: 12:00:00 (1637236780) <= t < 12:00:10 (1637236790) yes=2 no=1 maybe=0
+	totals, err = tr.Current(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]int{"yes": 7, "no": 3, "maybe": 1}, totals)
 }
 
 func TestBoolTracker(t *testing.T) {


### PR DESCRIPTION
Will be used to track unhealthy vs healthy webhook responses, and could be used to track channel success vs failure results, in a way that doesn't touch the db or use much Redis memory