### PR TITLE
Move msg level loop detection from courier

### DIFF
--- a/core/handlers/msg_created.go
+++ b/core/handlers/msg_created.go
@@ -99,7 +99,7 @@ func handleMsgCreated(ctx context.Context, rt *runtime.Runtime, tx *sqlx.Tx, oa 
 		}
 	}
 
-	msg, err := models.NewOutgoingMsg(rt.Config, oa.Org(), channel, scene.ContactID(), event.Msg, event.CreatedOn())
+	msg, err := models.NewOutgoingMsg(rt, oa.Org(), channel, scene.ContactID(), event.Msg, event.CreatedOn())
 	if err != nil {
 		return errors.Wrapf(err, "error creating outgoing message to %s", event.Msg.URN())
 	}

--- a/core/msgio/send_test.go
+++ b/core/msgio/send_test.go
@@ -46,7 +46,7 @@ func (m *msgSpec) createMsg(t *testing.T, rt *runtime.Runtime, oa *models.OrgAss
 	urn := urns.URN(fmt.Sprintf("tel:+250700000001?id=%d", m.URNID))
 
 	flowMsg := flows.NewMsgOut(urn, channelRef, "Hello", nil, nil, nil, flows.NilMsgTopic)
-	msg, err := models.NewOutgoingMsg(rt.Config, oaOrg.Org(), channel, m.ContactID, flowMsg, time.Now())
+	msg, err := models.NewOutgoingMsg(rt, oaOrg.Org(), channel, m.ContactID, flowMsg, time.Now())
 	require.NoError(t, err)
 
 	if m.HighPriority {


### PR DESCRIPTION
That way we don't bother queuing loopy messages to courier, updating their status later, or creating channel logs