### PR TITLE
Allow some cron jobs to run simultaneously on different instances

### DIFF
--- a/core/tasks/analytics/cron.go
+++ b/core/tasks/analytics/cron.go
@@ -13,21 +13,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	expirationLock = "stats"
-)
-
 func init() {
 	mailroom.AddInitFunction(StartAnalyticsCron)
 }
 
 // StartAnalyticsCron starts our cron job of posting stats every minute
 func StartAnalyticsCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, expirationLock, time.Second*60,
+	cron.Start(quit, rt, "stats", time.Second*60, true,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
-			return dumpAnalytics(ctx, rt)
+			return reportAnalytics(ctx, rt)
 		},
 	)
 	return nil
@@ -38,8 +34,8 @@ var (
 	waitCount    int64
 )
 
-// dumpAnalytics calculates a bunch of stats every minute and both logs them and sends them to librato
-func dumpAnalytics(ctx context.Context, rt *runtime.Runtime) error {
+// calculates a bunch of stats every minute and both logs them and sends them to librato
+func reportAnalytics(ctx context.Context, rt *runtime.Runtime) error {
 	// We wait 15 seconds since we fire at the top of the minute, the same as expirations.
 	// That way any metrics related to the size of our queue are a bit more accurate (all expirations can
 	// usually be handled in 15 seconds). Something more complicated would take into account the age of

--- a/core/tasks/campaigns/cron.go
+++ b/core/tasks/campaigns/cron.go
@@ -31,7 +31,7 @@ func init() {
 
 // StartCampaignCron starts our cron job of firing expired campaign events
 func StartCampaignCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, "campaign_event", time.Second*60,
+	cron.Start(quit, rt, "campaign_event", time.Second*60, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/expirations/cron.go
+++ b/core/tasks/expirations/cron.go
@@ -31,7 +31,7 @@ func init() {
 
 // StartExpirationCron starts our cron job of expiring runs every minute
 func StartExpirationCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, expirationLock, time.Second*60,
+	cron.Start(quit, rt, expirationLock, time.Second*60, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/handler/cron.go
+++ b/core/tasks/handler/cron.go
@@ -30,7 +30,7 @@ func init() {
 
 // StartRetryCron starts our cron job of retrying pending incoming messages
 func StartRetryCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, retryLock, time.Minute*5,
+	cron.Start(quit, rt, retryLock, time.Minute*5, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/incidents/end_incidents.go
+++ b/core/tasks/incidents/end_incidents.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func startEndCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, "end_incidents", time.Minute*3,
+	cron.Start(quit, rt, "end_incidents", time.Minute*3, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/ivr/cron.go
+++ b/core/tasks/ivr/cron.go
@@ -27,7 +27,7 @@ func init() {
 
 // StartIVRCron starts our cron job of retrying errored calls
 func StartIVRCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, retryIVRLock, time.Minute,
+	cron.Start(quit, rt, retryIVRLock, time.Minute, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()
@@ -35,7 +35,7 @@ func StartIVRCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error
 		},
 	)
 
-	cron.StartCron(quit, rt.RP, expireIVRLock, time.Minute,
+	cron.Start(quit, rt, expireIVRLock, time.Minute, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/msgs/retries.go
+++ b/core/tasks/msgs/retries.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func startCrons(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, retryMessagesLock, time.Second*60,
+	cron.Start(quit, rt, retryMessagesLock, time.Second*60, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/schedules/cron.go
+++ b/core/tasks/schedules/cron.go
@@ -24,7 +24,7 @@ func init() {
 
 // StartCheckSchedules starts our cron job of firing schedules every minute
 func StartCheckSchedules(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, scheduleLock, time.Minute*1,
+	cron.Start(quit, rt, scheduleLock, time.Minute*1, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/core/tasks/timeouts/cron.go
+++ b/core/tasks/timeouts/cron.go
@@ -29,7 +29,7 @@ func init() {
 
 // StartTimeoutCron starts our cron job of continuing timed out sessions every minute
 func StartTimeoutCron(rt *runtime.Runtime, wg *sync.WaitGroup, quit chan bool) error {
-	cron.StartCron(quit, rt.RP, timeoutLock, time.Second*60,
+	cron.Start(quit, rt, timeoutLock, time.Second*60, false,
 		func() error {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 			defer cancel()

--- a/mailroom.go
+++ b/mailroom.go
@@ -3,7 +3,6 @@ package mailroom
 import (
 	"context"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -165,8 +164,7 @@ func (mr *Mailroom) Start() error {
 
 	// if we have a librato token, configure it
 	if c.LibratoToken != "" {
-		host, _ := os.Hostname()
-		librato.Configure(c.LibratoUsername, c.LibratoToken, host, time.Second, mr.wg)
+		librato.Configure(c.LibratoUsername, c.LibratoToken, c.InstanceName, time.Second, mr.wg)
 		librato.Start()
 	}
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"io"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/nyaruka/goflow/utils"
@@ -60,13 +61,16 @@ type Config struct {
 	FCMKey            string `help:"the FCM API key used to notify Android relayers to sync"`
 	MailgunSigningKey string `help:"the signing key used to validate requests from mailgun"`
 
-	LogLevel string `help:"the logging level courier should use"`
-	UUIDSeed int    `help:"seed to use for UUID generation in a testing environment"`
-	Version  string `help:"the version of this mailroom install"`
+	InstanceName string `help:"the unique name of this instance used for analytics"`
+	LogLevel     string `help:"the logging level courier should use"`
+	UUIDSeed     int    `help:"seed to use for UUID generation in a testing environment"`
+	Version      string `help:"the version of this mailroom install"`
 }
 
 // NewDefaultConfig returns a new default configuration object
 func NewDefaultConfig() *Config {
+	hostname, _ := os.Hostname()
+
 	return &Config{
 		DB:         "postgres://temba:temba@localhost/temba?sslmode=disable&Timezone=UTC",
 		ReadonlyDB: "",
@@ -106,9 +110,10 @@ func NewDefaultConfig() *Config {
 		AWSAccessKeyID:     "",
 		AWSSecretAccessKey: "",
 
-		LogLevel: "error",
-		UUIDSeed: 0,
-		Version:  "Dev",
+		InstanceName: hostname,
+		LogLevel:     "error",
+		UUIDSeed:     0,
+		Version:      "Dev",
 	}
 }
 

--- a/utils/cron/cron_test.go
+++ b/utils/cron/cron_test.go
@@ -1,40 +1,105 @@
-package cron
+package cron_test
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/utils/cron"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCron(t *testing.T) {
-	_, _, _, rp := testsuite.Get()
+	_, rt, _, _ := testsuite.Get()
 
 	defer testsuite.Reset(testsuite.ResetRedis)
 
-	rc := rp.Get()
-	defer rc.Close()
+	createCronFunc := func(running *bool, fired *int, delays map[int]time.Duration, defaultDelay time.Duration) cron.Function {
+		return func() error {
+			if *running {
+				assert.Fail(t, "more than 1 thread is trying to run our cron job")
+			}
 
-	mutex := sync.RWMutex{}
-	fired := 0
-	quit := make(chan bool)
-
-	// our cron worker is just going to increment an int on every fire
-	increment := func() error {
-		mutex.Lock()
-		fired++
-		mutex.Unlock()
-		return nil
+			*running = true
+			delay := delays[*fired]
+			if delay == 0 {
+				delay = defaultDelay
+			}
+			time.Sleep(delay)
+			*fired++
+			*running = false
+			return nil
+		}
 	}
 
-	StartCron(quit, rp, "test", time.Millisecond*100, increment)
+	fired := 0
+	quit := make(chan bool)
+	running := false
 
-	// wait a bit, should only have fired three times (initial time + three timeouts)
-	time.Sleep(time.Millisecond * 320)
+	// start a job that takes ~100 ms and runs every 250ms
+	cron.Start(quit, rt, "test1", time.Millisecond*250, false, createCronFunc(&running, &fired, map[int]time.Duration{}, time.Millisecond*100))
+
+	// wait a bit, should only have fired three times (initial time + three repeats)
+	time.Sleep(time.Second * 1)
 	assert.Equal(t, 4, fired)
+
+	// tell the job to quit and check we don't see more fires
+	close(quit)
+
+	time.Sleep(time.Millisecond * 500)
+	assert.Equal(t, 4, fired)
+
+	fired = 0
+	quit = make(chan bool)
+	running = false
+
+	// simulate the job taking 400ms to run on the second fire, thus skipping the third fire
+	cron.Start(quit, rt, "test2", time.Millisecond*250, false, createCronFunc(&running, &fired, map[int]time.Duration{1: time.Millisecond * 400}, time.Millisecond*100))
+
+	time.Sleep(time.Second * 1)
+	assert.Equal(t, 3, fired)
+
+	close(quit)
+
+	// simulate two different instances running the same cron
+	cfg1 := *rt.Config
+	cfg2 := *rt.Config
+	cfg1.InstanceName = "instance1"
+	cfg2.InstanceName = "instance2"
+	rt1 := *rt
+	rt1.Config = &cfg1
+	rt2 := *rt
+	rt2.Config = &cfg2
+
+	fired1 := 0
+	fired2 := 0
+	quit = make(chan bool)
+	running = false
+
+	cron.Start(quit, &rt1, "test3", time.Millisecond*250, false, createCronFunc(&running, &fired1, map[int]time.Duration{}, time.Millisecond*100))
+	cron.Start(quit, &rt2, "test3", time.Millisecond*250, false, createCronFunc(&running, &fired2, map[int]time.Duration{}, time.Millisecond*100))
+
+	// same number of fires as if only a single instance was running it...
+	time.Sleep(time.Second * 1)
+	assert.Equal(t, 4, fired1+fired2) // can't say which instances will run the 4 fires
+
+	close(quit)
+
+	fired1 = 0
+	fired2 = 0
+	quit = make(chan bool)
+	running1 := false
+	running2 := false
+
+	// unless we start the cron with allInstances = true
+	cron.Start(quit, &rt1, "test4", time.Millisecond*250, true, createCronFunc(&running1, &fired1, map[int]time.Duration{}, time.Millisecond*100))
+	cron.Start(quit, &rt2, "test4", time.Millisecond*250, true, createCronFunc(&running2, &fired2, map[int]time.Duration{}, time.Millisecond*100))
+
+	// now both instances fire 4 times
+	time.Sleep(time.Second * 1)
+	assert.Equal(t, 4, fired1)
+	assert.Equal(t, 4, fired2)
 
 	close(quit)
 }
@@ -43,7 +108,7 @@ func TestNextFire(t *testing.T) {
 	tcs := []struct {
 		last     time.Time
 		interval time.Duration
-		next     time.Time
+		expected time.Time
 	}{
 		{time.Date(2000, 1, 1, 1, 1, 4, 0, time.UTC), time.Minute, time.Date(2000, 1, 1, 1, 2, 1, 0, time.UTC)},
 		{time.Date(2000, 1, 1, 1, 1, 44, 0, time.UTC), time.Minute, time.Date(2000, 1, 1, 1, 2, 1, 0, time.UTC)},
@@ -53,7 +118,7 @@ func TestNextFire(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		next := nextFire(tc.last, tc.interval)
-		assert.Equal(t, tc.next, next)
+		actual := cron.NextFire(tc.last, tc.interval)
+		assert.Equal(t, tc.expected, actual, "next fire mismatch for %s + %s", tc.last, tc.interval)
 	}
 }


### PR DESCRIPTION
And enable this for analytics so librato doesn't complain when one source doesn't report for a while