### PR TITLE
Clamp flow expiration values to valid ranges when loading flows

### DIFF
--- a/core/models/flows.go
+++ b/core/models/flows.go
@@ -179,8 +179,13 @@ SELECT ROW_TO_JSON(r) FROM (SELECT
 		jsonb_build_object(
 			'name', f.name,
 			'uuid', f.uuid,
-			'flow_type', f.flow_type, 
-			'expire_after_minutes', f.expires_after_minutes,
+			'flow_type', f.flow_type,
+			'expire_after_minutes', 
+				CASE f.flow_type 
+				WHEN 'M' THEN GREATEST(5, LEAST(f.expires_after_minutes, 43200))
+				WHEN 'V' THEN GREATEST(1, LEAST(f.expires_after_minutes, 15))
+				ELSE 0
+				END,
 			'metadata', jsonb_build_object(
 				'uuid', f.uuid, 
 				'id', f.id,

--- a/core/models/flows.go
+++ b/core/models/flows.go
@@ -233,7 +233,12 @@ SELECT ROW_TO_JSON(r) FROM (SELECT
 			'name', f.name,
 			'uuid', f.uuid,
 			'flow_type', f.flow_type, 
-			'expire_after_minutes', f.expires_after_minutes,
+			'expire_after_minutes', 
+				CASE f.flow_type 
+				WHEN 'M' THEN GREATEST(5, LEAST(f.expires_after_minutes, 43200))
+				WHEN 'V' THEN GREATEST(1, LEAST(f.expires_after_minutes, 15))
+				ELSE 0
+				END,
 			'metadata', jsonb_build_object(
 				'uuid', f.uuid, 
 				'id', f.id,

--- a/core/models/flows_test.go
+++ b/core/models/flows_test.go
@@ -1,10 +1,12 @@
 package models_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/nyaruka/goflow/assets"
+	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/mailroom/core/goflow"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -15,55 +17,119 @@ import (
 func TestLoadFlows(t *testing.T) {
 	ctx, rt, db, _ := testsuite.Get()
 
+	defer testsuite.Reset(testsuite.ResetAll)
+
 	db.MustExec(`UPDATE flows_flow SET metadata = '{"ivr_retry": 30}'::json WHERE id = $1`, testdata.IVRFlow.ID)
 	db.MustExec(`UPDATE flows_flow SET metadata = '{"ivr_retry": -1}'::json WHERE id = $1`, testdata.SurveyorFlow.ID)
+	db.MustExec(`UPDATE flows_flow SET expires_after_minutes = 720 WHERE id = $1`, testdata.Favorites.ID)
+	db.MustExec(`UPDATE flows_flow SET expires_after_minutes = 1 WHERE id = $1`, testdata.PickANumber.ID)          // too small for messaging
+	db.MustExec(`UPDATE flows_flow SET expires_after_minutes = 12345678 WHERE id = $1`, testdata.SingleMessage.ID) // too large for messaging
+	db.MustExec(`UPDATE flows_flow SET expires_after_minutes = 123 WHERE id = $1`, testdata.SurveyorFlow.ID)       // surveyor flows shouldn't have expires
 
 	sixtyMinutes := 60 * time.Minute
 	thirtyMinutes := 30 * time.Minute
 
-	tcs := []struct {
-		org              *testdata.Org
-		flowID           models.FlowID
-		flowUUID         assets.FlowUUID
-		expectedName     string
-		expectedIVRRetry *time.Duration
-	}{
-		{testdata.Org1, testdata.Favorites.ID, testdata.Favorites.UUID, "Favorites", &sixtyMinutes},    // will use default IVR retry
-		{testdata.Org1, testdata.IVRFlow.ID, testdata.IVRFlow.UUID, "IVR Flow", &thirtyMinutes},        // will have explicit IVR retry
-		{testdata.Org1, testdata.SurveyorFlow.ID, testdata.SurveyorFlow.UUID, "Contact Surveyor", nil}, // will have no IVR retry
-		{testdata.Org2, models.FlowID(0), assets.FlowUUID("51e3c67d-8483-449c-abf7-25e50686f0db"), "", nil},
+	type testcase struct {
+		org                *testdata.Org
+		flowID             models.FlowID
+		flowUUID           assets.FlowUUID
+		expectedName       string
+		expectedType       models.FlowType
+		expectedEngineType flows.FlowType
+		expectedExpire     int
+		expectedIVRRetry   *time.Duration
 	}
 
-	for i, tc := range tcs {
-		// test loading by UUID
-		flow, err := models.LoadFlowByUUID(ctx, db, tc.org.ID, tc.flowUUID)
+	tcs := []testcase{
+		{
+			testdata.Org1,
+			testdata.Favorites.ID,
+			testdata.Favorites.UUID,
+			"Favorites",
+			models.FlowTypeMessaging,
+			flows.FlowTypeMessaging,
+			720,
+			&sixtyMinutes, // uses default
+		},
+		{
+			testdata.Org1,
+			testdata.PickANumber.ID,
+			testdata.PickANumber.UUID,
+			"Pick a Number",
+			models.FlowTypeMessaging,
+			flows.FlowTypeMessaging,
+			5,             // clamped to minimum
+			&sixtyMinutes, // uses default
+		},
+		{
+			testdata.Org1,
+			testdata.SingleMessage.ID,
+			testdata.SingleMessage.UUID,
+			"Send All",
+			models.FlowTypeMessaging,
+			flows.FlowTypeMessaging,
+			43200,         // clamped to maximum
+			&sixtyMinutes, // uses default
+		},
+		{
+			testdata.Org1,
+			testdata.IVRFlow.ID,
+			testdata.IVRFlow.UUID,
+			"IVR Flow",
+			models.FlowTypeVoice,
+			flows.FlowTypeVoice,
+			5,
+			&thirtyMinutes, // uses explicit
+		},
+		{
+			testdata.Org1,
+			testdata.SurveyorFlow.ID,
+			testdata.SurveyorFlow.UUID,
+			"Contact Surveyor",
+			models.FlowTypeSurveyor,
+			flows.FlowTypeMessagingOffline,
+			0,   // explicit ignored
+			nil, // no retry
+		},
+	}
+
+	assertFlow := func(tc *testcase, dbFlow *models.Flow) {
+		desc := fmt.Sprintf("flow id=%d uuid=%s", tc.flowID, tc.flowUUID)
+
+		// check properties of flow model
+		assert.Equal(t, tc.flowID, dbFlow.ID())
+		assert.Equal(t, tc.flowUUID, dbFlow.UUID())
+		assert.Equal(t, tc.expectedName, dbFlow.Name(), "db name mismatch for %s", desc)
+		assert.Equal(t, tc.expectedIVRRetry, dbFlow.IVRRetryWait(), "db IVR retry mismatch for %s", desc)
+
+		// load as engine flow and check that too
+		flow, err := goflow.ReadFlow(rt.Config, dbFlow.Definition())
 		assert.NoError(t, err)
 
-		if tc.expectedName != "" {
-			assert.Equal(t, tc.flowID, flow.ID())
-			assert.Equal(t, tc.flowUUID, flow.UUID())
-			assert.Equal(t, tc.expectedName, flow.Name(), "%d: name mismatch", i)
-			assert.Equal(t, tc.expectedIVRRetry, flow.IVRRetryWait(), "%d: IVR retry mismatch", i)
+		assert.Equal(t, tc.flowUUID, flow.UUID(), "engine UUID mismatch for %s", desc)
+		assert.Equal(t, tc.flowUUID, flow.UUID(), "engine UUID mismatch for %s", desc)
+		assert.Equal(t, tc.expectedName, flow.Name(), "engine name mismatch for %s", desc)
+		assert.Equal(t, tc.expectedEngineType, flow.Type(), "engine type mismatch for %s", desc)
+		assert.Equal(t, tc.expectedExpire, flow.ExpireAfterMinutes(), "engine expire mismatch for %s", desc)
 
-			_, err := goflow.ReadFlow(rt.Config, flow.Definition())
-			assert.NoError(t, err)
-		} else {
-			assert.Nil(t, flow)
-		}
+	}
+
+	for _, tc := range tcs {
+		// test loading by UUID
+		dbFlow, err := models.LoadFlowByUUID(ctx, db, tc.org.ID, tc.flowUUID)
+		assert.NoError(t, err)
+		assertFlow(&tc, dbFlow)
 
 		// test loading by ID
-		flow, err = models.LoadFlowByID(ctx, db, tc.org.ID, tc.flowID)
+		dbFlow, err = models.LoadFlowByID(ctx, db, tc.org.ID, tc.flowID)
 		assert.NoError(t, err)
-
-		if tc.expectedName != "" {
-			assert.Equal(t, tc.flowID, flow.ID())
-			assert.Equal(t, tc.flowUUID, flow.UUID())
-			assert.Equal(t, tc.expectedName, flow.Name(), "%d: name mismatch", i)
-			assert.Equal(t, tc.expectedIVRRetry, flow.IVRRetryWait(), "%d: IVR retry mismatch", i)
-		} else {
-			assert.Nil(t, flow)
-		}
+		assertFlow(&tc, dbFlow)
 	}
+
+	// test loading flow with wrong org
+	dbFlow, err := models.LoadFlowByID(ctx, db, testdata.Org2.ID, testdata.Favorites.ID)
+	assert.NoError(t, err)
+	assert.Nil(t, dbFlow)
 }
 
 func TestFlowIDForUUID(t *testing.T) {


### PR DESCRIPTION
We got a lot of flows with junk values which we can also clean up on the RP side but important that engine always sets valid expirations