### PR TITLE
Consolidate how we interrupt sessions

### DIFF
--- a/core/models/msgs_test.go
+++ b/core/models/msgs_test.go
@@ -634,7 +634,7 @@ func TestNewOutgoingIVR(t *testing.T) {
 }
 
 func insertTestSession(t *testing.T, ctx context.Context, rt *runtime.Runtime, org *testdata.Org, contact *testdata.Contact, flow *testdata.Flow) *models.Session {
-	testdata.InsertFlowSession(rt.DB, org, contact, models.SessionStatusWaiting, nil)
+	testdata.InsertFlowSession(rt.DB, org, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdata.Org1.ID)
 	require.NoError(t, err)

--- a/core/models/msgs_test.go
+++ b/core/models/msgs_test.go
@@ -634,7 +634,7 @@ func TestNewOutgoingIVR(t *testing.T) {
 }
 
 func insertTestSession(t *testing.T, ctx context.Context, rt *runtime.Runtime, org *testdata.Org, contact *testdata.Contact, flow *testdata.Flow) *models.Session {
-	testdata.InsertFlowSession(rt.DB, org, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
+	testdata.InsertFlowSession(rt.DB, org, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, nil)
 
 	oa, err := models.GetOrgAssets(ctx, rt, testdata.Org1.ID)
 	require.NoError(t, err)

--- a/core/models/runs.go
+++ b/core/models/runs.go
@@ -1097,43 +1097,6 @@ WHERE
 	id = ANY ($1) AND status = 'W'
 `
 
-// InterruptContactSessions interrupts any waiting sessions for the given contacts
-func InterruptContactSessions(ctx context.Context, tx Queryer, contactIDs []ContactID) error {
-	return interruptContactSessions(ctx, tx, contactIDs, "")
-}
-
-// InterruptContactSessionsOfType interrupts any waiting sessions of the given type for the given contacts
-func InterruptContactSessionsOfType(ctx context.Context, tx Queryer, contactIDs []ContactID, sessionType FlowType) error {
-	return interruptContactSessions(ctx, tx, contactIDs, sessionType)
-}
-
-func interruptContactSessions(ctx context.Context, tx Queryer, contactIDs []ContactID, sessionType FlowType) error {
-	if len(contactIDs) == 0 {
-		return nil
-	}
-
-	sessionIDs := make([]SessionID, 0, len(contactIDs))
-	sql := `SELECT id FROM flows_flowsession WHERE status = 'W' AND contact_id = ANY($1)`
-	params := []interface{}{pq.Array(contactIDs)}
-
-	if sessionType != "" {
-		sql += ` AND session_type = $2;`
-		params = append(params, sessionType)
-	}
-
-	err := tx.SelectContext(ctx, &sessionIDs, sql, params...)
-	if err != nil {
-		return errors.Wrapf(err, "error selecting waiting sessions for contacts")
-	}
-
-	err = ExitSessions(ctx, tx, sessionIDs, SessionStatusInterrupted)
-	if err != nil {
-		return errors.Wrapf(err, "error exiting sessions")
-	}
-
-	return nil
-}
-
 // ExpireRunsAndSessions expires all the passed in runs and sessions. Note this should only be called
 // for runs that have no parents or no way of continuing
 func ExpireRunsAndSessions(ctx context.Context, db *sqlx.DB, runIDs []FlowRunID, sessionIDs []SessionID) error {

--- a/core/models/sessions.go
+++ b/core/models/sessions.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"context"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+// InterruptContactSessions interrupts any waiting sessions for the given contacts
+func InterruptContactSessions(ctx context.Context, tx Queryer, contactIDs []ContactID) error {
+	return interruptContactSessions(ctx, tx, contactIDs, "")
+}
+
+// InterruptContactSessionsOfType interrupts any waiting sessions of the given type for the given contacts
+func InterruptContactSessionsOfType(ctx context.Context, tx Queryer, contactIDs []ContactID, sessionType FlowType) error {
+	return interruptContactSessions(ctx, tx, contactIDs, sessionType)
+}
+
+func interruptContactSessions(ctx context.Context, tx Queryer, contactIDs []ContactID, sessionType FlowType) error {
+	if len(contactIDs) == 0 {
+		return nil
+	}
+
+	sessionIDs := make([]SessionID, 0, len(contactIDs))
+	sql := `SELECT id FROM flows_flowsession WHERE status = 'W' AND contact_id = ANY($1)`
+	params := []interface{}{pq.Array(contactIDs)}
+
+	if sessionType != "" {
+		sql += ` AND session_type = $2;`
+		params = append(params, sessionType)
+	}
+
+	err := tx.SelectContext(ctx, &sessionIDs, sql, params...)
+	if err != nil {
+		return errors.Wrapf(err, "error selecting waiting sessions for contacts")
+	}
+
+	err = ExitSessions(ctx, tx, sessionIDs, SessionStatusInterrupted)
+	if err != nil {
+		return errors.Wrapf(err, "error exiting sessions")
+	}
+
+	return nil
+}

--- a/core/models/sessions_test.go
+++ b/core/models/sessions_test.go
@@ -1,0 +1,63 @@
+package models_test
+
+import (
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/nyaruka/gocommon/dbutil/assertdb"
+	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/testsuite"
+	"github.com/nyaruka/mailroom/testsuite/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterruptContactSessions(t *testing.T) {
+	ctx, _, db, _ := testsuite.Get()
+
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting)
+
+	err := models.InterruptContactSessions(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting) // contact not included
+
+	// check other columns are correct on interrupted session
+	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
+}
+
+func TestInterruptContactSessionsOfType(t *testing.T) {
+	ctx, _, db, _ := testsuite.Get()
+
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeVoice, models.SessionStatusWaiting)
+
+	err := models.InterruptContactSessionsOfType(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID, testdata.George.ID}, models.FlowTypeMessaging)
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting) // wrong type
+
+	// check other columns are correct on interrupted session
+	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
+}
+
+func insertSessionAndRun(db *sqlx.DB, contact *testdata.Contact, sessionType models.FlowType, status models.SessionStatus) (models.SessionID, models.FlowRunID) {
+	sessionID := testdata.InsertFlowSession(db, testdata.Org1, contact, sessionType, status, nil)
+	runID := testdata.InsertFlowRun(db, testdata.Org1, sessionID, contact, testdata.Favorites, models.RunStatus(status), "", nil)
+	return sessionID, runID
+}
+
+func assertSessionAndRunStatus(t *testing.T, db *sqlx.DB, sessionID models.SessionID, status models.SessionStatus) {
+	assertdb.Query(t, db, `SELECT status FROM flows_flowsession WHERE id = $1`, sessionID).Columns(map[string]interface{}{"status": string(status)})
+	assertdb.Query(t, db, `SELECT status FROM flows_flowrun WHERE session_id = $1`, sessionID).Columns(map[string]interface{}{"status": string(status)})
+}

--- a/core/models/sessions_test.go
+++ b/core/models/sessions_test.go
@@ -14,12 +14,21 @@ import (
 func TestInterruptContactSessions(t *testing.T) {
 	ctx, _, db, _ := testsuite.Get()
 
-	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted)
-	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting)
-	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting)
-	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting)
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, models.NilConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
 
-	err := models.InterruptContactSessions(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})
+	// noop if no contacts
+	err := models.InterruptContactSessions(ctx, db, []models.ContactID{})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted)
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting)
+
+	err = models.InterruptContactSessions(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
@@ -34,10 +43,10 @@ func TestInterruptContactSessions(t *testing.T) {
 func TestInterruptContactSessionsOfType(t *testing.T) {
 	ctx, _, db, _ := testsuite.Get()
 
-	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted)
-	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting)
-	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting)
-	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeVoice, models.SessionStatusWaiting)
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, models.NilConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeVoice, models.SessionStatusWaiting, models.NilConnectionID)
 
 	err := models.InterruptContactSessionsOfType(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID, testdata.George.ID}, models.FlowTypeMessaging)
 	require.NoError(t, err)
@@ -51,8 +60,42 @@ func TestInterruptContactSessionsOfType(t *testing.T) {
 	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
 }
 
-func insertSessionAndRun(db *sqlx.DB, contact *testdata.Contact, sessionType models.FlowType, status models.SessionStatus) (models.SessionID, models.FlowRunID) {
-	sessionID := testdata.InsertFlowSession(db, testdata.Org1, contact, sessionType, status, nil)
+func TestInterruptChannelSessions(t *testing.T) {
+	ctx, _, db, _ := testsuite.Get()
+
+	cathy1ConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy)
+	cathy2ConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy)
+	bobConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Bob)
+	georgeConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.VonageChannel, testdata.George)
+
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, cathy1ConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, cathy2ConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, bobConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, georgeConnectionID)
+
+	// noop if no channels
+	err := models.InterruptChannelSessions(ctx, db, []models.ChannelID{})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted)
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting)
+
+	err = models.InterruptChannelSessions(ctx, db, []models.ChannelID{testdata.TwilioChannel.ID})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting) // channel not included
+
+	// check other columns are correct on interrupted session
+	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
+}
+
+func insertSessionAndRun(db *sqlx.DB, contact *testdata.Contact, sessionType models.FlowType, status models.SessionStatus, connID models.ConnectionID) (models.SessionID, models.FlowRunID) {
+	sessionID := testdata.InsertFlowSession(db, testdata.Org1, contact, sessionType, status, testdata.Favorites, connID, nil)
 	runID := testdata.InsertFlowRun(db, testdata.Org1, sessionID, contact, testdata.Favorites, models.RunStatus(status), "", nil)
 	return sessionID, runID
 }

--- a/core/models/sessions_test.go
+++ b/core/models/sessions_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInterruptContactSessions(t *testing.T) {
+func TestInterruptSessionsForContacts(t *testing.T) {
 	ctx, _, db, _ := testsuite.Get()
 
-	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, models.NilConnectionID)
-	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
-	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
-	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, testdata.Favorites, models.NilConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
 
 	// noop if no contacts
-	err := models.InterruptContactSessions(ctx, db, []models.ContactID{})
+	err := models.InterruptSessionsForContacts(ctx, db, []models.ContactID{})
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted)
@@ -28,7 +28,7 @@ func TestInterruptContactSessions(t *testing.T) {
 	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusWaiting)
 	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting)
 
-	err = models.InterruptContactSessions(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})
+	err = models.InterruptSessionsForContacts(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID})
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
@@ -40,15 +40,15 @@ func TestInterruptContactSessions(t *testing.T) {
 	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
 }
 
-func TestInterruptContactSessionsOfType(t *testing.T) {
+func TestInterruptSessionsOfTypeForContacts(t *testing.T) {
 	ctx, _, db, _ := testsuite.Get()
 
-	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, models.NilConnectionID)
-	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
-	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, models.NilConnectionID)
-	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeVoice, models.SessionStatusWaiting, models.NilConnectionID)
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, testdata.Favorites, models.NilConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeVoice, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID)
 
-	err := models.InterruptContactSessionsOfType(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID, testdata.George.ID}, models.FlowTypeMessaging)
+	err := models.InterruptSessionsOfTypeForContacts(ctx, db, []models.ContactID{testdata.Cathy.ID, testdata.Bob.ID, testdata.George.ID}, models.FlowTypeMessaging)
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
@@ -60,7 +60,7 @@ func TestInterruptContactSessionsOfType(t *testing.T) {
 	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
 }
 
-func TestInterruptChannelSessions(t *testing.T) {
+func TestInterruptSessionsForChannels(t *testing.T) {
 	ctx, _, db, _ := testsuite.Get()
 
 	cathy1ConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy)
@@ -68,13 +68,13 @@ func TestInterruptChannelSessions(t *testing.T) {
 	bobConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Bob)
 	georgeConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.VonageChannel, testdata.George)
 
-	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, cathy1ConnectionID)
-	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, cathy2ConnectionID)
-	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, bobConnectionID)
-	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, georgeConnectionID)
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, testdata.Favorites, cathy1ConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, cathy2ConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, bobConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, georgeConnectionID)
 
 	// noop if no channels
-	err := models.InterruptChannelSessions(ctx, db, []models.ChannelID{})
+	err := models.InterruptSessionsForChannels(ctx, db, []models.ChannelID{})
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted)
@@ -82,7 +82,7 @@ func TestInterruptChannelSessions(t *testing.T) {
 	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusWaiting)
 	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting)
 
-	err = models.InterruptChannelSessions(ctx, db, []models.ChannelID{testdata.TwilioChannel.ID})
+	err = models.InterruptSessionsForChannels(ctx, db, []models.ChannelID{testdata.TwilioChannel.ID})
 	require.NoError(t, err)
 
 	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
@@ -94,9 +94,43 @@ func TestInterruptChannelSessions(t *testing.T) {
 	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
 }
 
-func insertSessionAndRun(db *sqlx.DB, contact *testdata.Contact, sessionType models.FlowType, status models.SessionStatus, connID models.ConnectionID) (models.SessionID, models.FlowRunID) {
-	sessionID := testdata.InsertFlowSession(db, testdata.Org1, contact, sessionType, status, testdata.Favorites, connID, nil)
-	runID := testdata.InsertFlowRun(db, testdata.Org1, sessionID, contact, testdata.Favorites, models.RunStatus(status), "", nil)
+func TestInterruptSessionsForFlows(t *testing.T) {
+	ctx, _, db, _ := testsuite.Get()
+
+	cathy1ConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy)
+	cathy2ConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Cathy)
+	bobConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Bob)
+	georgeConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.VonageChannel, testdata.George)
+
+	session1ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusCompleted, testdata.Favorites, cathy1ConnectionID)
+	session2ID, _ := insertSessionAndRun(db, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, cathy2ConnectionID)
+	session3ID, _ := insertSessionAndRun(db, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, bobConnectionID)
+	session4ID, _ := insertSessionAndRun(db, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.PickANumber, georgeConnectionID)
+
+	// noop if no flows
+	err := models.InterruptSessionsForFlows(ctx, db, []models.FlowID{})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted)
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusWaiting)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting)
+
+	err = models.InterruptSessionsForFlows(ctx, db, []models.FlowID{testdata.Favorites.ID})
+	require.NoError(t, err)
+
+	assertSessionAndRunStatus(t, db, session1ID, models.SessionStatusCompleted) // wasn't waiting
+	assertSessionAndRunStatus(t, db, session2ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session3ID, models.SessionStatusInterrupted)
+	assertSessionAndRunStatus(t, db, session4ID, models.SessionStatusWaiting) // flow not included
+
+	// check other columns are correct on interrupted session
+	assertdb.Query(t, db, `SELECT count(*) FROM flows_flowsession WHERE ended_on IS NOT NULL AND wait_started_on IS NULL AND wait_expires_on IS NULL AND timeout_on IS NULL AND current_flow_id IS NULL AND id = $1`, session2ID).Returns(1)
+}
+
+func insertSessionAndRun(db *sqlx.DB, contact *testdata.Contact, sessionType models.FlowType, status models.SessionStatus, flow *testdata.Flow, connID models.ConnectionID) (models.SessionID, models.FlowRunID) {
+	sessionID := testdata.InsertFlowSession(db, testdata.Org1, contact, sessionType, status, flow, connID, nil)
+	runID := testdata.InsertFlowRun(db, testdata.Org1, sessionID, contact, flow, models.RunStatus(status), "", nil)
 	return sessionID, runID
 }
 

--- a/core/models/utils.go
+++ b/core/models/utils.go
@@ -18,6 +18,7 @@ type Queryer interface {
 
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
+	SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 	GetContext(ctx context.Context, value interface{}, query string, args ...interface{}) error
 }
 

--- a/core/runner/runner.go
+++ b/core/runner/runner.go
@@ -581,14 +581,14 @@ func StartFlowForContacts(
 	}
 
 	// build our list of contact ids
-	contactIDs := make([]flows.ContactID, len(triggers))
+	contactIDs := make([]models.ContactID, len(triggers))
 	for i := range triggers {
-		contactIDs[i] = triggers[i].Contact().ID()
+		contactIDs[i] = models.ContactID(triggers[i].Contact().ID())
 	}
 
 	// interrupt all our contacts if desired
 	if interrupt {
-		err = models.InterruptContactRuns(txCTX, tx, flow.FlowType(), contactIDs, start)
+		err = models.InterruptContactSessionsOfType(txCTX, tx, contactIDs, flow.FlowType())
 		if err != nil {
 			tx.Rollback()
 			return nil, errors.Wrap(err, "error interrupting contacts")
@@ -628,7 +628,7 @@ func StartFlowForContacts(
 
 			// interrupt this contact if appropriate
 			if interrupt {
-				err = models.InterruptContactRuns(txCTX, tx, flow.FlowType(), []flows.ContactID{session.Contact().ID()}, start)
+				err = models.InterruptContactSessionsOfType(txCTX, tx, []models.ContactID{models.ContactID(session.Contact().ID())}, flow.FlowType())
 				if err != nil {
 					tx.Rollback()
 					log.WithField("contact_uuid", session.Contact().UUID()).WithError(err).Errorf("error interrupting contact")

--- a/core/runner/runner.go
+++ b/core/runner/runner.go
@@ -588,7 +588,7 @@ func StartFlowForContacts(
 
 	// interrupt all our contacts if desired
 	if interrupt {
-		err = models.InterruptContactSessionsOfType(txCTX, tx, contactIDs, flow.FlowType())
+		err = models.InterruptSessionsOfTypeForContacts(txCTX, tx, contactIDs, flow.FlowType())
 		if err != nil {
 			tx.Rollback()
 			return nil, errors.Wrap(err, "error interrupting contacts")
@@ -628,7 +628,7 @@ func StartFlowForContacts(
 
 			// interrupt this contact if appropriate
 			if interrupt {
-				err = models.InterruptContactSessionsOfType(txCTX, tx, []models.ContactID{models.ContactID(session.Contact().ID())}, flow.FlowType())
+				err = models.InterruptSessionsOfTypeForContacts(txCTX, tx, []models.ContactID{models.ContactID(session.Contact().ID())}, flow.FlowType())
 				if err != nil {
 					tx.Rollback()
 					log.WithField("contact_uuid", session.Contact().UUID()).WithError(err).Errorf("error interrupting contact")

--- a/core/tasks/expirations/cron_test.go
+++ b/core/tasks/expirations/cron_test.go
@@ -23,9 +23,9 @@ func TestExpirations(t *testing.T) {
 	defer testsuite.Reset(testsuite.ResetData | testsuite.ResetRedis)
 
 	// create a few sessions
-	s1 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.SessionStatusWaiting, nil)
-	s2 := testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.SessionStatusWaiting, nil)
-	s3 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Bob, models.SessionStatusWaiting, nil)
+	s1 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
+	s2 := testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
+	s3 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
 
 	// simple run, no parent
 	r1ExpiresOn := time.Now()

--- a/core/tasks/expirations/cron_test.go
+++ b/core/tasks/expirations/cron_test.go
@@ -23,9 +23,9 @@ func TestExpirations(t *testing.T) {
 	defer testsuite.Reset(testsuite.ResetData | testsuite.ResetRedis)
 
 	// create a few sessions
-	s1 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
-	s2 := testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
-	s3 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, nil)
+	s1 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, nil)
+	s2 := testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, nil)
+	s3 := testdata.InsertFlowSession(db, testdata.Org1, testdata.Bob, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, nil)
 
 	// simple run, no parent
 	r1ExpiresOn := time.Now()

--- a/core/tasks/interrupts/interrupt_sessions_test.go
+++ b/core/tasks/interrupts/interrupt_sessions_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
-	"github.com/nyaruka/gocommon/uuids"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/testsuite"
@@ -18,29 +17,11 @@ func TestInterrupts(t *testing.T) {
 
 	defer testsuite.Reset(testsuite.ResetAll)
 
-	insertConnection := func(orgID models.OrgID, channelID models.ChannelID, contactID models.ContactID, urnID models.URNID) models.ConnectionID {
-		var connectionID models.ConnectionID
-		err := db.Get(&connectionID,
-			`INSERT INTO channels_channelconnection(created_on, modified_on, external_id, status, direction, connection_type, error_count, org_id, channel_id, contact_id, contact_urn_id) 
- 						VALUES(NOW(), NOW(), 'ext1', 'I', 'I', 'V', 0, $1, $2, $3, $4) RETURNING id`,
-			orgID, channelID, contactID, urnID,
-		)
-		assert.NoError(t, err)
-		return connectionID
-	}
+	insertSession := func(org *testdata.Org, contact *testdata.Contact, flow *testdata.Flow, connectionID models.ConnectionID) models.SessionID {
+		sessionID := testdata.InsertFlowSession(db, org, contact, models.FlowTypeMessaging, models.SessionStatusWaiting, flow, connectionID, nil)
 
-	insertSession := func(orgID models.OrgID, contactID models.ContactID, connectionID models.ConnectionID, currentFlowID models.FlowID) models.SessionID {
-		var sessionID models.SessionID
-		err := db.Get(&sessionID,
-			`INSERT INTO flows_flowsession(uuid, status, responded, created_on, org_id, contact_id, connection_id, current_flow_id, session_type)
-									VALUES($1, 'W', false, NOW(), $2, $3, $4, $5, 'M') RETURNING id`,
-			uuids.New(), orgID, contactID, connectionID, currentFlowID)
-		assert.NoError(t, err)
-
-		// give session one active run too
-		db.MustExec(`INSERT INTO flows_flowrun(uuid, is_active, status, created_on, modified_on, responded, contact_id, flow_id, session_id, org_id)
-			                            VALUES($1, TRUE, 'W', now(), now(), FALSE, $2, $3, $4, 1);`, uuids.New(), contactID, currentFlowID, sessionID)
-
+		// give session one waiting run too
+		testdata.InsertFlowRun(db, org, sessionID, contact, flow, models.RunStatusWaiting, "", nil)
 		return sessionID
 	}
 
@@ -81,18 +62,18 @@ func TestInterrupts(t *testing.T) {
 		db.MustExec(`UPDATE flows_flowsession SET status='C', ended_on=NOW() WHERE status = 'W';`)
 
 		// twilio connection
-		twilioConnectionID := insertConnection(testdata.Org1.ID, testdata.TwilioChannel.ID, testdata.Alexandria.ID, testdata.Alexandria.URNID)
+		twilioConnectionID := testdata.InsertConnection(db, testdata.Org1, testdata.TwilioChannel, testdata.Alexandria)
 
 		sessionIDs := make([]models.SessionID, 5)
 
 		// insert our dummy contact sessions
-		sessionIDs[0] = insertSession(testdata.Org1.ID, testdata.Cathy.ID, models.NilConnectionID, testdata.Favorites.ID)
-		sessionIDs[1] = insertSession(testdata.Org1.ID, testdata.George.ID, models.NilConnectionID, testdata.Favorites.ID)
-		sessionIDs[2] = insertSession(testdata.Org1.ID, testdata.Alexandria.ID, twilioConnectionID, testdata.Favorites.ID)
-		sessionIDs[3] = insertSession(testdata.Org1.ID, testdata.Bob.ID, models.NilConnectionID, testdata.PickANumber.ID)
+		sessionIDs[0] = insertSession(testdata.Org1, testdata.Cathy, testdata.Favorites, models.NilConnectionID)
+		sessionIDs[1] = insertSession(testdata.Org1, testdata.George, testdata.Favorites, models.NilConnectionID)
+		sessionIDs[2] = insertSession(testdata.Org1, testdata.Alexandria, testdata.Favorites, twilioConnectionID)
+		sessionIDs[3] = insertSession(testdata.Org1, testdata.Bob, testdata.PickANumber, models.NilConnectionID)
 
 		// a session we always end explicitly
-		sessionIDs[4] = insertSession(testdata.Org1.ID, testdata.Bob.ID, models.NilConnectionID, testdata.Favorites.ID)
+		sessionIDs[4] = insertSession(testdata.Org1, testdata.Bob, testdata.Favorites, models.NilConnectionID)
 
 		// create our task
 		task := &InterruptSessionsTask{

--- a/core/tasks/timeouts/cron_test.go
+++ b/core/tasks/timeouts/cron_test.go
@@ -24,9 +24,9 @@ func TestTimeouts(t *testing.T) {
 
 	// need to create a session that has an expired timeout
 	s1TimeoutOn := time.Now()
-	testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.SessionStatusWaiting, &s1TimeoutOn)
+	testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, &s1TimeoutOn)
 	s2TimeoutOn := time.Now().Add(time.Hour * 24)
-	testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.SessionStatusWaiting, &s2TimeoutOn)
+	testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, &s2TimeoutOn)
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/core/tasks/timeouts/cron_test.go
+++ b/core/tasks/timeouts/cron_test.go
@@ -24,9 +24,9 @@ func TestTimeouts(t *testing.T) {
 
 	// need to create a session that has an expired timeout
 	s1TimeoutOn := time.Now()
-	testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, &s1TimeoutOn)
+	testdata.InsertFlowSession(db, testdata.Org1, testdata.Cathy, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, &s1TimeoutOn)
 	s2TimeoutOn := time.Now().Add(time.Hour * 24)
-	testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, &s2TimeoutOn)
+	testdata.InsertFlowSession(db, testdata.Org1, testdata.George, models.FlowTypeMessaging, models.SessionStatusWaiting, testdata.Favorites, models.NilConnectionID, &s2TimeoutOn)
 
 	time.Sleep(10 * time.Millisecond)
 

--- a/testsuite/db.go
+++ b/testsuite/db.go
@@ -62,6 +62,13 @@ func (d *MockDB) NamedExecContext(ctx context.Context, query string, arg interfa
 	return d.real.NamedExecContext(ctx, query, arg)
 }
 
+func (d *MockDB) SelectContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+	if err := d.check("SelectContext"); err != nil {
+		return err
+	}
+	return d.real.SelectContext(ctx, dest, query, args...)
+}
+
 func (d *MockDB) GetContext(ctx context.Context, value interface{}, query string, args ...interface{}) error {
 	if err := d.check("GetContext"); err != nil {
 		return err

--- a/testsuite/testdata/channels.go
+++ b/testsuite/testdata/channels.go
@@ -25,3 +25,13 @@ func InsertChannel(db *sqlx.DB, org *Org, channelType, name string, schemes []st
 	))
 	return &Channel{id, uuid}
 }
+
+// InsertConnection inserts a channel connection
+func InsertConnection(db *sqlx.DB, org *Org, channel *Channel, contact *Contact) models.ConnectionID {
+	var id models.ConnectionID
+	must(db.Get(&id,
+		`INSERT INTO channels_channelconnection(created_on, modified_on, external_id, status, direction, connection_type, error_count, org_id, channel_id, contact_id, contact_urn_id) 
+		VALUES(NOW(), NOW(), 'ext1', 'I', 'I', 'V', 0, $1, $2, $3, $4) RETURNING id`, org.ID, channel.ID, contact.ID, contact.URNID,
+	))
+	return id
+}

--- a/testsuite/testdata/flows.go
+++ b/testsuite/testdata/flows.go
@@ -57,7 +57,7 @@ func InsertFlowStart(db *sqlx.DB, org *Org, flow *Flow, contacts []*Contact) mod
 }
 
 // InsertFlowSession inserts a flow session
-func InsertFlowSession(db *sqlx.DB, org *Org, contact *Contact, sessionType models.FlowType, status models.SessionStatus, timeoutOn *time.Time) models.SessionID {
+func InsertFlowSession(db *sqlx.DB, org *Org, contact *Contact, sessionType models.FlowType, status models.SessionStatus, currentFlow *Flow, connectionID models.ConnectionID, timeoutOn *time.Time) models.SessionID {
 	now := time.Now()
 	tomorrow := now.Add(time.Hour * 24)
 
@@ -69,8 +69,8 @@ func InsertFlowSession(db *sqlx.DB, org *Org, contact *Contact, sessionType mode
 
 	var id models.SessionID
 	must(db.Get(&id,
-		`INSERT INTO flows_flowsession(uuid, org_id, contact_id, status, responded, created_on, session_type, timeout_on, wait_started_on, wait_expires_on, wait_resume_on_expire) 
-		 VALUES($1, $2, $3, $4, TRUE, NOW(), $5, $6, $7, $8, FALSE) RETURNING id`, uuids.New(), org.ID, contact.ID, status, sessionType, timeoutOn, waitStartedOn, waitExpiresOn,
+		`INSERT INTO flows_flowsession(uuid, org_id, contact_id, status, responded, created_on, session_type, current_flow_id, connection_id, timeout_on, wait_started_on, wait_expires_on, wait_resume_on_expire) 
+		 VALUES($1, $2, $3, $4, TRUE, NOW(), $5, $6, $7, $8, $9, $10, FALSE) RETURNING id`, uuids.New(), org.ID, contact.ID, status, sessionType, currentFlow.ID, connectionID, timeoutOn, waitStartedOn, waitExpiresOn,
 	))
 	return id
 }


### PR DESCRIPTION
End goal is to have all code that exits sessions go thru `ExitSessions` which will then be responsible for updating `Contact.current_flow` accordingly