### PR TITLE
Move `interrupt_channel` task into `tasks/interrupts`

### DIFF
--- a/core/tasks/interrupts/interrupt_channel.go
+++ b/core/tasks/interrupts/interrupt_channel.go
@@ -1,4 +1,4 @@
-package channels
+package interrupts
 
 import (
 	"context"

--- a/core/tasks/interrupts/interrupt_channel_test.go
+++ b/core/tasks/interrupts/interrupt_channel_test.go
@@ -1,4 +1,4 @@
-package channels
+package interrupts_test
 
 import (
 	"testing"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/tasks/interrupts"
 	"github.com/nyaruka/mailroom/core/tasks/msgs"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
@@ -52,7 +53,7 @@ func TestInterruptChannel(t *testing.T) {
 	assertdb.Query(t, db, `SELECT count(*) FROM msgs_msg WHERE status = 'F' and channel_id = $1`, testdata.TwilioChannel.ID).Returns(0)
 
 	// twilio channel task
-	task := &InterruptChannelTask{
+	task := &interrupts.InterruptChannelTask{
 		ChannelID: testdata.TwilioChannel.ID,
 	}
 
@@ -83,7 +84,7 @@ func TestInterruptChannel(t *testing.T) {
 	})
 
 	// vonage channel task
-	task = &InterruptChannelTask{
+	task = &interrupts.InterruptChannelTask{
 		ChannelID: testdata.VonageChannel.ID,
 	}
 

--- a/core/tasks/interrupts/interrupt_sessions.go
+++ b/core/tasks/interrupts/interrupt_sessions.go
@@ -7,7 +7,6 @@ import (
 	"github.com/nyaruka/mailroom/core/models"
 	"github.com/nyaruka/mailroom/core/tasks"
 	"github.com/nyaruka/mailroom/runtime"
-
 	"github.com/pkg/errors"
 )
 

--- a/core/tasks/interrupts/interrupt_sessions_test.go
+++ b/core/tasks/interrupts/interrupt_sessions_test.go
@@ -1,4 +1,4 @@
-package interrupts
+package interrupts_test
 
 import (
 	"testing"
@@ -7,9 +7,9 @@ import (
 	"github.com/nyaruka/gocommon/dbutil/assertdb"
 	_ "github.com/nyaruka/mailroom/core/handlers"
 	"github.com/nyaruka/mailroom/core/models"
+	"github.com/nyaruka/mailroom/core/tasks/interrupts"
 	"github.com/nyaruka/mailroom/testsuite"
 	"github.com/nyaruka/mailroom/testsuite/testdata"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,7 +77,7 @@ func TestInterrupts(t *testing.T) {
 		sessionIDs[4] = insertSession(testdata.Org1, testdata.Bob, testdata.Favorites, models.NilCallID)
 
 		// create our task
-		task := &InterruptSessionsTask{
+		task := &interrupts.InterruptSessionsTask{
 			SessionIDs: []models.SessionID{sessionIDs[4]},
 			ContactIDs: tc.contactIDs,
 			FlowIDs:    tc.flowIDs,


### PR DESCRIPTION
The mailroom cmd isn't currently importing "github.com/nyaruka/mailroom/core/tasks/channels" so this task isn't actually available (unit tests work because they import that package directly)

Figured might as well keep it in "github.com/nyaruka/mailroom/core/tasks/interrupts" anyways