### PR TITLE
Remove no longer used `Org.uses_topups`

### DIFF
--- a/core/models/orgs.go
+++ b/core/models/orgs.go
@@ -68,10 +68,9 @@ const (
 // Org is mailroom's type for RapidPro orgs. It also implements the envs.Environment interface for GoFlow
 type Org struct {
 	o struct {
-		ID         OrgID    `json:"id"`
-		Suspended  bool     `json:"is_suspended"`
-		UsesTopups bool     `json:"uses_topups"`
-		Config     null.Map `json:"config"`
+		ID        OrgID    `json:"id"`
+		Suspended bool     `json:"is_suspended"`
+		Config    null.Map `json:"config"`
 	}
 	env envs.Environment
 }
@@ -81,9 +80,6 @@ func (o *Org) ID() OrgID { return o.o.ID }
 
 // Suspended returns whether the org has been suspended
 func (o *Org) Suspended() bool { return o.o.Suspended }
-
-// UsesTopups returns whether the org uses topups
-func (o *Org) UsesTopups() bool { return o.o.UsesTopups }
 
 // DateFormat returns the date format for this org
 func (o *Org) DateFormat() envs.DateFormat { return o.env.DateFormat() }
@@ -252,7 +248,6 @@ const selectOrgByID = `
 SELECT ROW_TO_JSON(o) FROM (SELECT
 	id,
 	is_suspended,
-	uses_topups,
 	COALESCE(o.config::json,'{}'::json) AS config,
 	(SELECT CASE date_format WHEN 'D' THEN 'DD-MM-YYYY' WHEN 'M' THEN 'MM-DD-YYYY' END) AS date_format, 
 	'tt:mm' AS time_format,

--- a/core/models/topups_test.go
+++ b/core/models/topups_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nyaruka/mailroom/testsuite/testdata"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTopups(t *testing.T) {
@@ -62,13 +61,4 @@ func TestTopups(t *testing.T) {
 		assert.Equal(t, tc.TopupID, topup)
 		tx.MustExec(`INSERT INTO orgs_topupcredits(is_squashed, used, topup_id) VALUES(TRUE, 1, $1)`, tc.OrgID)
 	}
-
-	// topups can be disabled for orgs
-	tx.MustExec(`UPDATE orgs_org SET uses_topups = FALSE WHERE id = $1`, testdata.Org1.ID)
-	org, err := models.LoadOrg(ctx, rt.Config, tx, testdata.Org1.ID)
-	require.NoError(t, err)
-
-	topup, err := models.AllocateTopups(ctx, tx, rp, org, 1)
-	assert.NoError(t, err)
-	assert.Equal(t, models.NilTopupID, topup)
 }


### PR DESCRIPTION
We haven't used this for a while - used to be that we used it to fail messages if an org was using topups and didn't have any.. we currently send those messages but suspend the org